### PR TITLE
fixed bug: Can't running `minil test`.

### DIFF
--- a/lib/Minilla/WorkDir.pm
+++ b/lib/Minilla/WorkDir.pm
@@ -187,7 +187,7 @@ sub dist_test {
         my $guard = pushd($self->dir);
         my @cmd = ($^X, 'Build', 'test');
         Minilla::Logger::infof("%s\n", "@cmd");
-        return system(@_);
+        return system(@cmd);
     }
 }
 


### PR DESCRIPTION
when I trying master's HEAD rev, It cause followings error:

```
$ minil test 
Creating working directory: /Users/yoshimin/project/perl/Foo-Bar/.build/BKkZlprD
Detecting project name from directory name.
Retrieving meta data from lib/Foo/Bar.pm.
Name: Foo::Bar
Abstract: It's new $module
Version: 0.01
fatal: bad default revision 'HEAD'
Writing MANIFEST file
Writing release tests: xt/minimum_version.t
Writing release tests: xt/cpan_meta.t
Writing release tests: xt/pod.t
Writing release tests: xt/spelling.t
$ perl Build.PL
Created MYMETA.yml and MYMETA.json
Creating new 'Build' script for 'Foo-Bar' version '0.01'
Merging cpanfile prereqs to MYMETA.yml
Merging cpanfile prereqs to MYMETA.json
$ perl Build build
Building Foo-Bar
perl Build test
sh: -c: line 0: syntax error near unexpected token `0x7fd30c3d2b40'
sh: -c: line 0: `Minilla::WorkDir=HASH(0x7fd30c3d2b40)'
```

This patch will fix this error.
