### PR TITLE
There is no reason that 'no_index' entry is existing in generated Build.PL

### DIFF
--- a/lib/Minilla/ModuleMaker/ModuleBuild.pm
+++ b/lib/Minilla/ModuleMaker/ModuleBuild.pm
@@ -61,7 +61,6 @@ my %args = (
         'Module::Build' => 0.38,
     },
 
-    no_index    => { 'directory' => [ 'inc' ] },
     name        => '<% $dist_name %>',
     module_name => '<% $name %>',
 


### PR DESCRIPTION
It's different from META.json. It's confusing.
