### PR TITLE
Ignore directories start with a dot if include_dotfiles is false

### DIFF
--- a/lib/Minilla.pm
+++ b/lib/Minilla.pm
@@ -178,8 +178,8 @@ C<exclude_match> option. Files matching the patterns are not gathered.
     [FileGatherer]
     include_dotfiles=false
 
-By default, files will not be included in dist if they begin with a dot. This option
-doesn't care directory, but only files currently.
+By default, files will not be included in dist if they begin with a dot. This goes
+both for files and for directories.
 
 In almost all cases, the default value (false) is correct.
 

--- a/lib/Minilla/FileGatherer.pm
+++ b/lib/Minilla/FileGatherer.pm
@@ -4,7 +4,6 @@ use warnings;
 use utf8;
 use File::pushd;
 use File::Spec;
-use File::Basename;
 use ExtUtils::Manifest 1.54 qw(maniskip);
 
 use Minilla::Git;
@@ -41,7 +40,9 @@ sub gather_files {
         @files = grep { !$skip->($_) } @files;
     }
     unless ($self->include_dotfiles) {
-        @files = grep { basename($_) !~ qr/^\./ } @files;
+        @files = grep {
+            !(grep { $_ =~ qr/^\./ } split m!/!, _normalize($_))
+        } @files;
     }
 
     return @files;

--- a/t/filegatherer.t
+++ b/t/filegatherer.t
@@ -29,7 +29,7 @@ subtest 'FileGatherer' => sub {
             include_dotfiles => 1,
         )->gather_files('.');
 
-        is(join(',', sort @files), '.gitignore,META.json,README,foo');
+        is(join(',', sort @files), '.dot/dot,.gitignore,META.json,README,foo,xtra/.dot,xtra/.dotdir/dot');
     };
 
     subtest 'MANIFEST.SKIP' => sub {
@@ -50,6 +50,8 @@ sub init {
     my $guard = pushd(tempdir());
 
     mkdir 'local';
+    mkdir '.dot';
+    mkpath 'xtra/.dotdir';
     mkpath 'extlib/lib';
     spew('local/foo', '...');
     spew('extlib/lib/Foo.pm', '...');
@@ -57,6 +59,9 @@ sub init {
     spew('README', 'rrr');
     spew('META.json', 'mmm');
     spew('foo', 'mmm');
+    spew('.dot/dot', 'dot');
+    spew('xtra/.dot', 'dot');
+    spew('xtra/.dotdir/dot', '...');
 
     git_init();
     git_add('.');


### PR DESCRIPTION
For compatible with Dist::Milla.

rel #33
