### PR TITLE
Force name delimiter to be single hyphen.

### DIFF
--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -110,7 +110,7 @@ sub authors {
         return $meta->authors;
     }
     $self->config->{authors} || $self->metadata->authors;
-} 
+}
 
 sub abstract {
     my $self = shift;
@@ -121,7 +121,7 @@ sub abstract {
         return $meta->abstract;
     }
     $self->config->{abstract} || $self->metadata->abstract;
-} 
+}
 
 sub _build_dir {
     my $self = shift;
@@ -172,6 +172,7 @@ sub _build_dist_name {
         infof("Detecting project name from directory name.\n");
         $dist_name = do {
             local $_ = basename($self->dir);
+            $_ =~ s!--!-!g;
             $_ =~ s!\Ap5-!!;
             $_;
         };

--- a/t/project/dist_name.t
+++ b/t/project/dist_name.t
@@ -1,0 +1,56 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use File::Basename qw(basename);
+use t::Util;
+
+use Minilla;
+use Minilla::Project;
+
+subtest 'Single hyphen delimiter' => sub {
+    my $guard = pushd( tempdir( 'App-foobar-XXXX', CLEANUP => 1 ) );
+    my $delimiter = '-';
+    test_dist_name( $guard, $delimiter );
+};
+
+subtest 'Double hyphen delimiter' => sub {
+    my $guard = pushd( tempdir( 'App--foobar--XXXX', CLEANUP => 1 ) );
+    my $delimiter = '--';
+    test_dist_name( $guard, $delimiter );
+};
+
+subtest 'Single hyphen delimiter with "p5-" prefix' => sub {
+    my $guard = pushd( tempdir( 'p5-App-foobar-XXXX', CLEANUP => 1 ) );
+    my $delimiter = '-';
+    test_dist_name( $guard, $delimiter );
+};
+
+subtest 'Double hyphen delimiter with "p5-" prefix' => sub {
+    my $guard = pushd( tempdir( 'p5-App--foobar--XXXX', CLEANUP => 1 ) );
+    my $delimiter = '--';
+    test_dist_name( $guard, $delimiter );
+};
+
+done_testing;
+
+sub test_dist_name {
+    my ($guard, $delimiter) = @_;
+
+    my $base_name = basename( $guard->{_pushd} );
+    my ($module_name) = $base_name =~ /$delimiter([^-]*)$/;
+
+    mkpath('lib/App/foobar');
+    spew("lib/App/foobar/$module_name.pm", <<"...");
+package App::foobar::$module_name;
+1;
+...
+
+    git_init();
+    git_add('.');
+    git_commit('-m', 'foo');
+
+    my $project = Minilla::Project->new();
+    is($project->dist_name, "App-foobar-$module_name");
+}
+


### PR DESCRIPTION
The CPAN indexer may be confused if the base name (it is used in Build.PL as "name") uses double hyphens as name space delimiter (e.g. Foo--Bar).

Yes, I know we should not use double hyphens as delimiters, but GitHub converts double colons to double hyphens when we create a new repository, like so;
http://gyazo.com/0e1b40244556e14481c6bcadc310a5bb

So I fixed it.
