### PR TITLE
fixed a bug that empty file couldn't be included to dist archive.

### DIFF
--- a/lib/Minilla/WorkDir.pm
+++ b/lib/Minilla/WorkDir.pm
@@ -207,7 +207,7 @@ sub dist {
 
         my $tar = Archive::Tar->new;
         for (@{$self->manifest_files}) {
-            $tar->add_data(File::Spec->catfile($self->project->dist_name . '-' . $self->project->version, $_), slurp($_));
+            $tar->add_data(File::Spec->catfile($self->project->dist_name . '-' . $self->project->version, $_), scalar slurp($_));
         }
         $tar->write($tarball, COMPRESS_GZIP);
         infof("Wrote %s\n", $tarball);

--- a/t/work_dir/dist.t
+++ b/t/work_dir/dist.t
@@ -25,6 +25,7 @@ subtest 'rewrite pod' => sub {
     );
     $profile->generate();
     write_minil_toml('Acme-Foo');
+    spew 'empty.txt', '';
 
     git_init();
     git_add('.');
@@ -58,6 +59,9 @@ subtest 'rewrite pod' => sub {
         "Valid MANIFEST file was generated.",
     );
     like($tar->get_content('Acme-Foo-0.01/MANIFEST'), qr{^Build.PL$}sm, 'Contains Build.PL in MANIFEST');
+
+    like($tar->get_content('Acme-Foo-0.01/MANIFEST'), qr{^empty.txt$}sm, 'Contains empty.txt in MANIFEST');
+    ok($tar->contains_file('Acme-Foo-0.01/empty.txt'), 'Contains empty.txt in archive');
 };
 
 done_testing;


### PR DESCRIPTION
Archive::Tar::File#_new_from_data doesn't accept undef, caused by calling slurp() in array context with empty $fh.
