### PR TITLE
omitted '(no author)' line from contributor list.

### DIFF
--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -443,6 +443,7 @@ sub _build_contributors {
     my %is_author = map { $normalize->($_) => 1 } @{$self->authors};
     @lines = grep { !$is_author{$normalize->($_)} } @lines;
     @lines = grep { $_ ne 'Your Name <you@example.com>' } @lines;
+    @lines = grep { ! /^\(no author\) <\(no author\)\@[\d\w\-]+>$/ } @lines;
     \@lines;
 }
 


### PR DESCRIPTION
One of my old repos has moved cvs -> svn -> git, unfortunately cvs2svn command replaced unknown author commit like below:

```
commit 4989a20276c897d9f296a348c2767e95f33d6fe9
Author: (no author) <(no author)@190414af-bbfa-0310-9d04-6f9e040fc871>
Date:   Wed Jun 23 11:11:44 2004 +0000

    New repository initialized by cvs2svn.
```
