### PR TITLE
Suppress and fix trivial but misleading messages in "new" subcommand

### DIFF
--- a/lib/Minilla/Profile/Base.pm
+++ b/lib/Minilla/Profile/Base.pm
@@ -152,7 +152,7 @@ our $VERSION = "<% $version %>";
 
 =head1 NAME
 
-<% $module %> - It's new $module
+<% $module %> - It's new <% $module %>
 
 =head1 SYNOPSIS
 

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -438,7 +438,7 @@ sub _build_contributors {
     };
     my @lines = do {
         my %uniq;
-        reverse grep { !$uniq{$normalize->($_)}++ } split /\n/, `git log --format="%aN <%aE>"`
+        reverse grep { !$uniq{$normalize->($_)}++ } split /\n/, `git log --format="%aN <%aE>" 2>/dev/null`
     };
     my %is_author = map { $normalize->($_) => 1 } @{$self->authors};
     @lines = grep { !$is_author{$normalize->($_)} } @lines;


### PR DESCRIPTION
Before:

```
Writing lib/Foo/Bar.pm
Writing Changes
Writing t/00_compile.t
Writing .travis.yml
Writing .gitignore
Writing LICENSE
Writing cpanfile
Initializing git Foo::Bar
[Foo-Bar] $ git init
Initialized empty Git repository in /home/hirose31/LOCAL/Foo-Bar/.git/
Detecting project name from directory name.
Retrieving meta data from lib/Foo/Bar.pm.
Name: Foo::Bar
Abstract: It's new $module #✔
Version: 0.01
fatal: bad default revision 'HEAD' #✔
[Foo-Bar] $ git add .
Finished to create Foo::Bar
```

After:

```
$ minil new Foo::Bar
Writing lib/Foo/Bar.pm
Writing Changes
Writing t/00_compile.t
Writing .travis.yml
Writing .gitignore
Writing LICENSE
Writing cpanfile
Initializing git Foo::Bar
[Foo-Bar] $ git init
Initialized empty Git repository in /home/hirose31/LOCAL/Foo-Bar/.git/
Detecting project name from directory name.
Retrieving meta data from lib/Foo/Bar.pm.
Name: Foo::Bar
Abstract: It's new Foo::Bar #✔
Version: 0.01
[Foo-Bar] $ git add .
Finished to create Foo::Bar
```
