### PR TITLE
Added check git exist on exec some cli commands.

### DIFF
--- a/lib/Minilla/CLI/Dist.pm
+++ b/lib/Minilla/CLI/Dist.pm
@@ -8,12 +8,15 @@ use File::Basename qw(basename);
 use File::Copy qw(copy);
 
 use Minilla::Project;
-use Minilla::Util qw(parse_options);
+use Minilla::Util qw(check_git parse_options);
 
 sub run {
     my ($self, @args) = @_;
 
     my $test = 1;
+
+    check_git;
+
     parse_options(
         \@args,
         'test!' => \$test,

--- a/lib/Minilla/CLI/Migrate.pm
+++ b/lib/Minilla/CLI/Migrate.pm
@@ -3,11 +3,14 @@ use strict;
 use warnings;
 use utf8;
 
-use Minilla::Util qw(slurp spew);
+use Minilla::Util qw(check_git slurp spew);
 use Minilla::Migrate;
 
 sub run {
     my ($self, @args) = @_;
+
+    check_git;
+
     Minilla::Migrate->new()->run;
 }
 

--- a/lib/Minilla/CLI/New.pm
+++ b/lib/Minilla/CLI/New.pm
@@ -5,7 +5,7 @@ use utf8;
 use File::pushd;
 use File::Path qw(mkpath);
 
-use Minilla::Util qw(cmd parse_options);
+use Minilla::Util qw(check_git cmd parse_options);
 use Minilla::Logger;
 
 sub run {
@@ -23,6 +23,8 @@ sub run {
 
     my $module = shift @args or errorf("Missing module name\n");
        $module =~ s!-!::!g;
+
+    check_git;
 
     $username ||= `git config user.name`;
     $username =~ s/\n$//;

--- a/lib/Minilla/CLI/Test.pm
+++ b/lib/Minilla/CLI/Test.pm
@@ -6,7 +6,7 @@ use File::pushd;
 
 use Minilla::WorkDir;
 use Minilla::Project;
-use Minilla::Util qw(parse_options);
+use Minilla::Util qw(check_git parse_options);
 
 sub run {
     my ($self, @args) = @_;
@@ -15,6 +15,9 @@ sub run {
     my $author    = 1;
     my $automated = 0;
     my $all       = 0;
+
+    check_git;
+
     parse_options(
         \@args,
         'release!'   => \$release,

--- a/lib/Minilla/Util.pm
+++ b/lib/Minilla/Util.pm
@@ -5,6 +5,7 @@ use utf8;
 use Carp ();
 use File::Basename ();
 use File::Spec ();
+use File::Which 'which';
 use Minilla::Logger ();
 use Getopt::Long ();
 use Cwd();
@@ -19,7 +20,9 @@ our @EXPORT_OK = qw(
     edit_file require_optional
     cmd cmd_perl
     pod_escape
-    parse_options);
+    parse_options
+    check_git
+);
 
 our %EXPORT_TAGS = (
     all => \@EXPORT_OK
@@ -164,6 +167,12 @@ sub pod_escape {
     my %POD_ESCAPE = ( '<' => 'E<lt>', '>' => 'E<gt>' );
     s!([<>])!$POD_ESCAPE{$1}!ge;
     $_;
+}
+
+sub check_git {
+    unless (which 'git') {
+        Minilla::Logger::errorf("The \"git\" executable has not been found.\n");
+    }
 }
 
 1;


### PR DESCRIPTION
Fixed errors on exec some cli commands if git does not exist.
For example:

$ perl -I../lib minil new Test
Can't exec "git": No such file or directory at ../lib/Minilla/CLI/New.pm line 27.
Use of uninitialized value $username in substitution (s///) at ../lib/Minilla/CLI/New.pm line 28.
Can't exec "git": No such file or directory at ../lib/Minilla/CLI/New.pm line 30.
Use of uninitialized value $email in substitution (s///) at ../lib/Minilla/CLI/New.pm line 31

Added:
If git does not exist - displayed message 'The "git" executable has not been found.' and script terminates.
