### PR TITLE
skip -x test that has a portability issue on win32

### DIFF
--- a/t/work_dir/copy.t
+++ b/t/work_dir/copy.t
@@ -34,7 +34,10 @@ subtest 'copy' => sub {
     my $work_dir = Minilla::Project->new()->work_dir;
     ok($work_dir);
     ok -f catfile($work_dir->dir, 'bin/foo');
-    ok -x catfile($work_dir->dir, 'bin/foo');
+    SKIP: {
+        skip "-x test is not portable", 1 if $^O eq 'MSWin32';
+        ok -x catfile($work_dir->dir, 'bin/foo');
+    }
 };
 
 done_testing;


### PR DESCRIPTION
See perlport; chmod has an issue as well.
