### PR TITLE
`badges` option allows only service name.

### DIFF
--- a/lib/Minilla.pm
+++ b/lib/Minilla.pm
@@ -184,9 +184,9 @@ See L<CPAN::Meta::Spec>.
 
 =item badges
 
-    badges = [ "[![alt text](http://example.com/badge.jpg)](http://example.com)", ... ]
+    badges = ['travis', 'coveralls']
 
-Embed badges image (e.g. Travis-CI) to README.md. It ought to be array and each elements must be markdown notation for image.
+Embed badges image (e.g. Travis-CI) to README.md. It ought to be array and each elements must be service name. Now, supported services are only 'travis' and 'coveralls'.
 
 =item PL_files
 


### PR DESCRIPTION
In past, `badges` option allows markdown notation as you like. It is not fine.
So this patch fixes that problem. `badges` option accepts service name only (now this option supports 'travis' and 'coveralls').
