### PR TITLE
Cleanup tutorial document

### DIFF
--- a/lib/Minilla/Tutorial.pod
+++ b/lib/Minilla/Tutorial.pod
@@ -102,7 +102,7 @@ The easiest way to convert existing dependencies to cpanfile is to use the comma
     on test => sub {
         requires 'Test::More', '0.86';
     }
-        
+    
     ...
 
 You can redirect the output to cpanfile if you like. It is important to pass --no-configure option here, since otherwise modules like ExtUtils::MakeMaker will be included. It is not required with Minilla setup, since Minilla knows which configuration tool (installer) to use and include them in META files upon the releases. You can leave that out from the cpanfile.
@@ -155,7 +155,7 @@ Also, new C<Build.PL>, C<META.json> and C<README.md> are added in your
 working directory for git-friendliness. C<git add> them and commit it.
 
    > git add Build.PL META.json README.md && git commit -m "git stuff"
-    
+
 Now you're ready to roll a new release with Minilla. Before doing so,
 convert your C<Changes> file format a little bit, and make sure you
 have a following header in the top:
@@ -167,9 +167,9 @@ have a following header in the top:
 The C<{{$NEXT}}> is a template variable that gets replaced with the
 version and date string, when you make a next release. This is almost
 the I<only> change you're required to make in your code base.
- 
+
 Now, run the release command:
-  
+
     > minil release
 
 to make a new release, in the same way described above for a new Minilla


### PR DESCRIPTION
Summary: made pod coincident with Dist::Milla's as well as possible (and look clean).

Each commit represent:
- Change all shell prompts to `>` (which is also used in Dist::Milla's tutorial)
  - (before this commit, `>` and `%` are jumbled)
- Removed "I don't released yet" phrase.
- Trimed unnecessary white spaces that are absent in Dist::Milla's document.

(Residual diffs: indentations of prompts in Dist::Milla are 2 spaces, while that of this module are 4 spaces. I don't know the reason.)
