### PR TITLE
Add '~/.pause' description to tutorial pod.

### DIFF
--- a/lib/Minilla/Tutorial.pod
+++ b/lib/Minilla/Tutorial.pod
@@ -51,6 +51,9 @@ Now, make sure you have Changes file ready and have a new entry under C<{{$NEXT}
 
     % $EDITOR Changes
     % minil test
+
+Before you proceed to release step, please ensure the C<~/.pause> file is configured correctly because Minilla uses L<CPAN::Uploader> to upload your distribution to CPAN.  You can specify the location of PAUSE configuration file on I<minil.toml> if you want to.  See L<Minilla/"CONFIGURATION"> for further information.
+
     % minil release
 
 And your first release is done. The release is tagged on git and all the changes automatically made are committed to git as well.


### PR DESCRIPTION
I believe Minilla will become standard tool for releasing to CPAN, because it is less-configuration and easy to use for Perl newbies.
I understand it is the must-have-knowledge for CPAN authors that ".pause" file is required for releasing to CPAN by many release tools nowadays, but I think that knowledge is too concealed for newbies.
IMHO, at lease the pointer to CPAN::Upload would be present in the tutorial document.
