### PR TITLE
Fixed an error that occurs when use the string as a parameter of XSUtil section.

### DIFF
--- a/lib/Minilla/ModuleMaker/ModuleBuild.pm
+++ b/lib/Minilla/ModuleMaker/ModuleBuild.pm
@@ -87,8 +87,8 @@ my %args = (
 ? if( $project->use_xsutil ){
     needs_compiler_c99 => <?= $project->needs_compiler_c99 ?>,
     needs_compiler_cpp => <?= $project->needs_compiler_cpp ?>,
-    generate_ppport_h => <?= $project->generate_ppport_h ?>,
-    generate_xshelper_h => <?= $project->generate_xshelper_h ?>,
+    generate_ppport_h => '<?= $project->generate_ppport_h ?>',
+    generate_xshelper_h => '<?= $project->generate_xshelper_h ?>',
     cc_warnings => <?= $project->cc_warnings ?>,
 ? }
 );

--- a/t/module_maker/xsutil.t
+++ b/t/module_maker/xsutil.t
@@ -14,8 +14,8 @@ test(
         like( $buildpl, qr!use Module::Build::XSUtil;! );
         like( $buildpl, qr!needs_compiler_c99\s+=>\s+0! );
         like( $buildpl, qr!needs_compiler_cpp\s+=>\s+0! );
-        like( $buildpl, qr!generate_ppport_h\s+=>\s+0! );
-        like( $buildpl, qr!generate_xshelper_h\s+=>\s+0! );
+        like( $buildpl, qr!generate_ppport_h\s+=>\s+\'0\'! );
+        like( $buildpl, qr!generate_xshelper_h\s+=>\s+\'0\'! );
         like( $buildpl, qr!cc_warnings\s+=>\s+0! );
     }
 );
@@ -32,9 +32,22 @@ test(
         like( $buildpl, qr!use Module::Build::XSUtil;! );
         like( $buildpl, qr!needs_compiler_c99\s+=>\s+1! );
         like( $buildpl, qr!needs_compiler_cpp\s+=>\s+1! );
-        like( $buildpl, qr!generate_ppport_h\s+=>\s+1! );
-        like( $buildpl, qr!generate_xshelper_h\s+=>\s+1! );
+        like( $buildpl, qr!generate_ppport_h\s+=>\s+\'1\'! );
+        like( $buildpl, qr!generate_xshelper_h\s+=>\s+\'1\'! );
         like( $buildpl, qr!cc_warnings\s+=>\s+1! );
+    }
+);
+
+test(
+    {   
+        generate_ppport_h   => 'lib/ppport.h',
+        generate_xshelper_h => 'lib/xshelper.h',
+    },
+    sub {
+        my $buildpl = slurp('Build.PL');
+        like( $buildpl, qr!use Module::Build::XSUtil;! );
+        like( $buildpl, qr!generate_ppport_h\s+=>\s+\'lib/ppport\.h\'! );
+        like( $buildpl, qr!generate_xshelper_h\s+=>\s+\'lib/xshelper\.h\'! );
     }
 );
 


### PR DESCRIPTION
### Problem

Error occurs when use a string as a parameter of XSUtil section.
- minil.toml

```
[XSUtil]
generate_ppport_h = "lib/ppport.h"
```
- Error

```
Bareword "lib" not allowed while "strict subs" in use at Build.PL line 18.
Bareword "ppport" not allowed while "strict subs" in use at Build.PL line 18.
Bareword "h" not allowed while "strict subs" in use at Build.PL line 18.
Execution of Build.PL aborted due to compilation errors.
```
### Solution

Quote the value of the parameter that allows the string.
