### PR TITLE
change to 'minil release' will not update version number  if fake release

### DIFF
--- a/lib/Minilla/Release/RewriteChanges.pm
+++ b/lib/Minilla/Release/RewriteChanges.pm
@@ -7,6 +7,7 @@ use Minilla::Util qw(slurp_raw spew_raw);
 sub run {
     my ($self, $project, $opts) = @_;
     return if $opts->{dry_run};
+    return if !$ENV{FAKE_RELEASE};
 
     my $content = slurp_raw('Changes');
     $content =~ s!\{\{\$NEXT\}\}!

--- a/lib/Minilla/Release/Tag.pm
+++ b/lib/Minilla/Release/Tag.pm
@@ -14,10 +14,12 @@ sub run {
         infof("DRY-RUN.  Would have tagged version $ver.\n");
         return;
     }
-
-    my $tag = $project->format_tag($ver);
-    cmd('git', 'tag', $tag);
-    cmd('git', "push", 'origin', tag => $tag);
+    
+    if(!$ENV{FAKE_RELEASE}){
+        my $tag = $project->format_tag($ver);
+        cmd('git', 'tag', $tag);
+        cmd('git', "push", 'origin', tag => $tag);
+    }
 }
 
 1;


### PR DESCRIPTION
change to if choice FAKE_RELEASE  , not update git tag version and Changes
