### PR TITLE
ignore /Build.bat (generated when you run "perl Build.PL" on Win32)

### DIFF
--- a/lib/Minilla/Migrate.pm
+++ b/lib/Minilla/Migrate.pm
@@ -228,6 +228,7 @@ sub migrate_gitignore {
         /.build
         /_build_params
         /Build
+        /Build.bat
         !Build/
         !META.json
         !LICENSE

--- a/lib/Minilla/Profile/Base.pm
+++ b/lib/Minilla/Profile/Base.pm
@@ -193,6 +193,7 @@ Revision history for Perl extension <% $dist %>
 /.build/
 /_build/
 /Build
+/Build.bat
 /blib
 
 /carton.lock


### PR DESCRIPTION
Win32 patch, as always.
