### PR TITLE
do not test twice on installation by default.

### DIFF
--- a/lib/Minilla/CLI/Install.pm
+++ b/lib/Minilla/CLI/Install.pm
@@ -26,7 +26,7 @@ sub run {
 
     cmd(
         'cpanm',
-        ($test ? () : ('--notest')),
+        '--notest',
         $tar
     );
     unlink($tar) unless Minilla->debug;


### PR DESCRIPTION
cpanm doesn't need to test a release-tested tarball, does it?
