### PR TITLE
git init before migrating if necessary

### DIFF
--- a/lib/Minilla/Migrate.pm
+++ b/lib/Minilla/Migrate.pm
@@ -35,6 +35,12 @@ sub _build_project {
 sub run {
     my $self = shift;
 
+    if (!-d '.git') {
+        # init git repo
+        infof("Initializing git\n");
+        cmd('git', 'init');
+    }
+
     my $guard = pushd($self->project->dir);
 
     # Generate cpanfile from Build.PL/Makefile.PL


### PR DESCRIPTION
to make it easier to migrate a subversion-controlled (or version-uncontrolled = just-extracted-from-tarball) repository.

It's nicer to migrate from subversion to git first not to lose history, though.
