### PR TITLE
Now, minil release --no-test does work

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -58,6 +58,7 @@ recommends 'Test::CPAN::Meta';
 on 'test' => sub {
     requires 'Test::More' => '0.98';
     requires 'Test::Requires' => 0;
+    requires 'Test::Output';
     requires 'File::Temp';
     recommends 'Devel::CheckLib';
     suggests 'Dist::Zilla';

--- a/lib/Minilla/Release/DistTest.pm
+++ b/lib/Minilla/Release/DistTest.pm
@@ -6,6 +6,8 @@ use utf8;
 sub run {
     my ($self, $project, $opts) = @_;
 
+    $opts->{test} or return;
+
     local $ENV{RELEASE_TESTING} = 1;
     my $work_dir = $project->work_dir();
     if ($work_dir->dist_test) {

--- a/t/cli/release_notest.t
+++ b/t/cli/release_notest.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use Test::Requires 'Version::Next';
+use t::Util;
+use Minilla::Profile::ModuleBuild;
+use Minilla::CLI::Release;
+use Test::Output;
+
+my $repo = tempdir();
+{
+    my $guard = pushd($repo);
+    cmd('git', 'init', '--bare');
+}
+
+my $guard = pushd(tempdir());
+
+Minilla::Profile::ModuleBuild->new(
+    author => 'hoge',
+    dist => 'Acme-Foo',
+    module => 'Acme::Foo',
+    path => 'Acme/Foo.pm',
+    version => '0.01',
+)->generate();
+write_minil_toml('Acme-Foo');
+git_init_add_commit();
+git_remote('add', 'origin', "file://$repo");
+
+{
+    local $ENV{PERL_MM_USE_DEFAULT} = 1;
+    local $ENV{PERL_MINILLA_SKIP_CHECK_CHANGE_LOG} = 1;
+    local $ENV{FAKE_RELEASE} = 1;
+    stdout_unlike {
+        Minilla::CLI::Release->run(qw/--notest/);
+    } qr/All tests successful/, 'notest option';
+    pass 'released.';
+}
+
+done_testing;
+


### PR DESCRIPTION
Until now, minil release option's "--no-test" does not work.
