### PR TITLE
Enable to display own status badges on each branch.

### DIFF
--- a/lib/Minilla/Git.pm
+++ b/lib/Minilla/Git.pm
@@ -5,7 +5,7 @@ use utf8;
 
 use parent qw(Exporter);
 
-our @EXPORT = qw(git_ls_files git_init git_add git_rm git_commit git_config git_remote git_submodule_add git_submodules git_submodule_files);
+our @EXPORT = qw(git_ls_files git_init git_add git_rm git_commit git_config git_remote git_branch git_checkout git_submodule_add git_submodules git_submodule_files);
 
 use Minilla::Util qw(cmd);
 
@@ -31,6 +31,14 @@ sub git_commit {
 
 sub git_remote {
     cmd('git', 'remote', @_);
+}
+
+sub git_branch {
+    cmd('git', 'branch', @_);
+}
+
+sub git_checkout {
+    cmd('git', 'checkout', @_);
 }
 
 sub git_ls_files {

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -17,7 +17,7 @@ use Minilla::Metadata;
 use Minilla::WorkDir;
 use Minilla::ReleaseTest;
 use Minilla::ModuleMaker::ModuleBuild;
-use Minilla::Util qw(slurp_utf8 find_dir cmd spew_raw slurp_raw);
+use Minilla::Util qw(slurp_utf8 find_dir cmd spew_raw slurp_raw get_branch);
 
 use Moo;
 
@@ -544,12 +544,14 @@ sub regenerate_readme_md {
 
         my @badges;
         if ($user_name && $repository_name) {
+            my $branch = get_branch()
+                or return;
             for my $badge (@{$self->badges}) {
                 if ($badge eq 'travis') {
-                    push @badges, "[![Build Status](https://travis-ci.org/$user_name/$repository_name.png?branch=master)](https://travis-ci.org/$user_name/$repository_name)";
+                    push @badges, "[![Build Status](https://travis-ci.org/$user_name/$repository_name.png?branch=$branch)](https://travis-ci.org/$user_name/$repository_name)";
                 }
                 if ($badge eq 'coveralls') {
-                    push @badges, "[![Coverage Status](https://coveralls.io/repos/$user_name/$repository_name/badge.png?branch=master)](https://coveralls.io/r/$user_name/$repository_name?branch=master)"
+                    push @badges, "[![Coverage Status](https://coveralls.io/repos/$user_name/$repository_name/badge.png?branch=$branch)](https://coveralls.io/r/$user_name/$repository_name?branch=$branch)"
                 }
             }
         }

--- a/lib/Minilla/Release/Commit.pm
+++ b/lib/Minilla/Release/Commit.pm
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 use utf8;
 
-use Minilla::Util qw(find_file cmd);
+use Minilla::Util qw(find_file cmd get_branch);
 use Minilla::Logger;
 
 sub run {
@@ -32,20 +32,10 @@ sub _push_to_origin {
     my ($self) = @_;
 
     # git v1.7.10 is required?
-    my $branch = _get_branch()
+    my $branch = get_branch()
         or return;
-    $branch =~ s/\n//g;
     infof("Pushing to origin\n");
     cmd('git', 'push', 'origin', $branch);
-}
-
-sub _get_branch {
-    open my $fh, '<', '.git/HEAD';
-    chomp( my $head = do { local $/; <$fh> });
-    close $fh;
-
-    my ($branch) = $head =~ m!ref: refs/heads/(\S+)!;
-    return $branch;
 }
 
 1;

--- a/lib/Minilla/Util.pm
+++ b/lib/Minilla/Util.pm
@@ -22,6 +22,7 @@ our @EXPORT_OK = qw(
     pod_escape
     parse_options
     check_git
+    get_branch
 );
 
 our %EXPORT_TAGS = (
@@ -173,6 +174,16 @@ sub check_git {
     unless (which 'git') {
         Minilla::Logger::errorf("The \"git\" executable has not been found.\n");
     }
+}
+
+sub get_branch {
+    open my $fh, '<', '.git/HEAD';
+    chomp( my $head = do { local $/; <$fh> });
+    close $fh;
+
+    my ($branch) = $head =~ m!ref: refs/heads/(\S+)!;
+    $branch =~ s/\n//g;
+    return $branch;
 }
 
 1;

--- a/t/Util.pm
+++ b/t/Util.pm
@@ -24,7 +24,7 @@ plan skip_all => "No git configuration" unless `git config user.email` =~ /\@/;
 $ENV{PERL_CPANM_HOME} = tempdir();
 
 our @EXPORT = (
-    qw(git_init_add_commit write_minil_toml),
+    qw(git_init_add_commit git_create_checkout_branch write_minil_toml),
     qw(tempdir pushd),
     @Minilla::Git::EXPORT, @Minilla::Util::EXPORT_OK, qw(spew),
     qw(catfile),
@@ -35,6 +35,12 @@ sub git_init_add_commit() {
     git_init();
     git_add('.');
     git_commit('-m', 'initial import');
+}
+
+sub git_create_checkout_branch() {
+    my $branch = 'new-branch';
+    git_branch($branch);
+    git_checkout($branch);
 }
 
 sub write_minil_toml {

--- a/t/project/badge.t
+++ b/t/project/badge.t
@@ -40,12 +40,13 @@ subtest 'Badge' => sub {
             name   => 'Acme-Foo',
             badges => ['travis', 'coveralls'],
         });
+        git_create_checkout_branch();
         $project->regenerate_files;
 
         open my $fh, '<', 'README.md';
         ok chomp (my $got = <$fh>);
 
-        my $badge_markdowns = ["[![Build Status](https://travis-ci.org/tokuhirom/Minilla.png?branch=master)](https://travis-ci.org/tokuhirom/Minilla)", "[![Coverage Status](https://coveralls.io/repos/tokuhirom/Minilla/badge.png?branch=master)](https://coveralls.io/r/tokuhirom/Minilla?branch=master)"];
+        my $badge_markdowns = ["[![Build Status](https://travis-ci.org/tokuhirom/Minilla.png?branch=new-branch)](https://travis-ci.org/tokuhirom/Minilla)", "[![Coverage Status](https://coveralls.io/repos/tokuhirom/Minilla/badge.png?branch=new-branch)](https://coveralls.io/r/tokuhirom/Minilla?branch=new-branch)"];
         my $expected = join(' ', @$badge_markdowns);
         is $got, $expected;
     };


### PR DESCRIPTION
Master branch status was always referred to as  badge images for README.md.
I think each branch should refer to own branch status.
