### PR TITLE
allow_pureperl requires Module::Build 0.4005 

### DIFF
--- a/lib/Minilla/ModuleMaker/ModuleBuild.pm
+++ b/lib/Minilla/ModuleMaker/ModuleBuild.pm
@@ -30,12 +30,13 @@ sub prereqs {
     my $prereqs = +{
         configure => {
             requires => {
-                'Module::Build'       => 0.38,
+                'Module::Build'       => $project->module_build_version,
                 'CPAN::Meta'          => 0,
                 'CPAN::Meta::Prereqs' => 0,
             }
         }
     };
+
     if( $project->use_xsutil ){
         delete $prereqs->{configure}{requires}{'Module::Build'};
         $prereqs->{configure}{requires}{'Module::Build::XSUtil'} = '0.03';
@@ -71,7 +72,7 @@ my %args = (
     dynamic_config       => 0,
 
     configure_requires => {
-        'Module::Build' => 0.38,
+        'Module::Build' => <?= $project->module_build_version ?>,
     },
 
     name            => '<?= $project->dist_name ?>',

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -96,6 +96,12 @@ sub allow_pureperl {
     $self->config->{allow_pureperl} ? 1 : 0;
 }
 
+sub module_build_version {
+    my $self = shift;
+    # --pureperl-only support was added in 0.4005
+    $self->allow_pureperl ? 0.4005 : 0.38;
+}
+
 sub version {
     my $self = shift;
     my $version = $self->config->{version} || $self->metadata->version;

--- a/t/module_maker/allow_pureperl.t
+++ b/t/module_maker/allow_pureperl.t
@@ -8,10 +8,14 @@ use Minilla::Profile::ModuleBuild;
 use Minilla::Project;
 
 test(1, sub {
-    like(slurp('Build.PL'), qr{allow_pureperl\s+=>\s+1});
+    my $build_pl = slurp('Build.PL');
+    like($build_pl, qr{allow_pureperl\s+=>\s+1});
+    like($build_pl, qr{'Module::Build'\s+=>\s+0\.4005});
 });
 test(0, sub {
-    like(slurp('Build.PL'), qr{allow_pureperl\s+=>\s+0});
+    my $build_pl = slurp('Build.PL');
+    like($build_pl, qr{allow_pureperl\s+=>\s+0});
+    like($build_pl, qr{'Module::Build'\s+=>\s+0\.38});
 });
 
 done_testing;


### PR DESCRIPTION
allow_pureperl / --pureperl-only requires Module::Build-0.4005.

ref. http://blog.64p.org/entry/2013/04/27/091019
