### PR TITLE
Fix case that there is no '.pause'.

### DIFF
--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -528,7 +528,7 @@ sub generate_minil_toml {
     );
 
     my %pause;
-    if (eval { %pause = Config::Identity::PAUSE->load; 1; }) {
+    if (eval { %pause = Config::Identity::PAUSE->load; 1; } && exists $pause{user}) {
         my $user = uc($pause{user});
         $content .= qq{\nauthority="cpan:${user}"\n},
     }


### PR DESCRIPTION
`Config::Identity::PAUSE->load` returns nothing without exception
if there is no pause configuration file like `~/.pause`. In such
case, eval block returns true, but uninitialized value reference
is arisen because `$pause{user}` is `undef`.
