### PR TITLE
Support release testing on Module::Build::Tiny

### DIFF
--- a/lib/Minilla/CLI/Test.pm
+++ b/lib/Minilla/CLI/Test.pm
@@ -38,7 +38,7 @@ sub run {
     $ENV{AUTOMATED_TESTING} =1 if $automated;
 
     my $work_dir = $project->work_dir;
-    my $code = $work_dir->dist_test(@args);
+    my $code = $work_dir->dist_test();
     exit $code;
 }
 

--- a/lib/Minilla/ModuleMaker/ModuleBuild.pm
+++ b/lib/Minilla/ModuleMaker/ModuleBuild.pm
@@ -5,6 +5,7 @@ use utf8;
 use Data::Section::Simple qw(get_data_section);
 use Text::MicroTemplate qw(render_mt);
 use Data::Dumper;
+use Minilla::Util qw(cmd_perl);
 
 use Moo;
 
@@ -42,6 +43,10 @@ sub prereqs {
         $prereqs->{configure}{requires}{'Module::Build::XSUtil'} = '0.03';
     }
     return $prereqs;
+}
+
+sub run_tests {
+    cmd_perl('Build', 'test');
 }
 
 1;
@@ -89,7 +94,7 @@ my %args = (
 ? if( $project->tap_harness_args ){
     tap_harness_args => <?= Dumper($project->tap_harness_args) ?>,
 ? }
-    
+
 ? if( $project->use_xsutil ){
     needs_compiler_c99 => <?= $project->needs_compiler_c99 ?>,
     needs_compiler_cpp => <?= $project->needs_compiler_cpp ?>,

--- a/lib/Minilla/WorkDir.pm
+++ b/lib/Minilla/WorkDir.pm
@@ -189,7 +189,7 @@ sub dist_test {
 
     eval {
         my $guard = pushd($self->dir);
-        cmd_perl('Build', 'test');
+        $self->project->module_maker->run_tests();
     };
     return $@ ? 1 : 0;
 }

--- a/t/module_maker/tiny/run_tests.t
+++ b/t/module_maker/tiny/run_tests.t
@@ -1,0 +1,73 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use Test::Requires {'Module::Build::Tiny', 0.035};
+use t::Util;
+use FindBin;
+use lib "$FindBin::Bin/../../../lib";
+use File::Temp qw(tempdir);
+use File::pushd;
+
+use Minilla::CLI;
+use Minilla::CLI::New;
+use Minilla::ReleaseTest;
+
+my $original_write_release_tests = *Minilla::ReleaseTest::write_release_tests{CODE};
+undef *Minilla::ReleaseTest::write_release_tests;
+*Minilla::ReleaseTest::write_release_tests = sub {}; # Do nothing
+
+my $minil = File::Spec->rel2abs('script/minil');
+
+subtest 'dist test' => sub {
+    my $guard = pushd(tempdir(CLEANUP => 1));
+
+    Minilla::CLI::New->run('Acme::Speciality', '--username' => 'foo', '--email' => 'bar', '--profile', 'ModuleBuildTiny');
+
+    chdir 'Acme-Speciality';
+
+    {
+        mkdir 'xt';
+        open my $fh, '>', 'xt/fail.t';
+        print $fh <<'...';
+use strict;
+use warnings;
+use Test::More;
+ok 0; # Failure
+done_testing;
+...
+        system 'git add .';
+    }
+
+    subtest 'run only t/*.t and pass all' => sub {
+        is test_by(''), 0;
+        is test_by('--automated'), 0;
+        is test_by('--author'), 0;
+    };
+
+    subtest 'run t/*.t and xt/*.t and fail' => sub {
+        isnt test_by('--release'), 0;
+        isnt test_by('--all'), 0;
+    };
+};
+
+sub test_by {
+    my $run_opt = shift;
+
+    $ENV{RELEASE_TESTING}   = 0;
+    $ENV{AUTHOR_TESTING}    = 0;
+    $ENV{AUTOMATED_TESTING} = 0;
+
+    my $pid = fork;
+    fail("Fork failed") unless defined $pid;
+    if ($pid) {
+        waitpid($pid, 0);
+        return $?;
+    }
+    else {
+        Minilla::CLI->new->run('test', $run_opt);
+    }
+}
+
+done_testing;
+


### PR DESCRIPTION
Activate to run `xt/*.t` when `minil test` is running with `--release` or `--all` option.
