### PR TITLE
Fixed the problem where the default is not set to MBT

### DIFF
--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -545,8 +545,10 @@ sub generate_minil_toml {
     }
     warn $@ if $@;
 
-    # Experimental Module::Build::Tiny support
-    if ($profile eq 'ModuleBuildTiny') {
+    if ($profile eq 'ModuleBuild') {
+        $content .= qq{\nmodule_maker="ModuleBuild"\n};
+    }
+    else {
         $content .= qq{\nmodule_maker="ModuleBuildTiny"\n};
     }
 


### PR DESCRIPTION
Changes said...

```
v1.0.0 2014-05-12T04:47:31Z

    - Default module builder is now Module::Builder::Tiny.
      (tokuhirom)
```

but it seems not working. So I fixed it.
