### PR TITLE
Save abstract more properly

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -5,7 +5,7 @@ requires 'parent' => '0';
 requires 'Archive::Tar', '1.60';
 requires 'Time::Piece' => 1.16; # older Time::Piece was broken
 requires 'version';
-requires 'CPAN::Meta';
+requires 'CPAN::Meta' => '2.110420'; # save with UTF-8 encoding
 requires 'ExtUtils::Manifest', 1.54; # make maniskip a public routine, and allow an argument to override $mfile
 suggests 'Devel::PPPort'; # XS
 requires 'TAP::Harness::Env'; # From 5.19.5

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -2,6 +2,7 @@ package Minilla::Project;
 use strict;
 use warnings;
 use utf8;
+use Encode qw(decode_utf8);
 
 use TOML 0.92 qw(from_toml);
 use File::Basename qw(basename dirname);
@@ -407,7 +408,7 @@ sub cpan_meta {
             "url"     => "http://search.cpan.org/perldoc?CPAN::Meta::Spec"
         },
         license        => [ $self->license->meta2_name ],
-        abstract       => $self->abstract,
+        abstract       => decode_utf8($self->abstract),
         dynamic_config => 0,
         version        => $self->version,
         name           => $self->dist_name,


### PR DESCRIPTION
Mojibake occurs if abstract has non-latin-1 characters.
