### PR TITLE
make parsing of the git url more robust

### DIFF
--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -470,8 +470,11 @@ sub extract_git_info {
     if ( `git remote show -n origin` =~ /URL: (.*)$/m && $1 ne 'origin' ) {
         # XXX Make it public clone URL, but this only works with github
         my $git_url = $1;
-        $git_url =~ s![\w\-]+\@([^:]+):!git://$1/!;
+        $git_url =~ s!(?:[\w\-]+\@)?([^:]+):!git://$1/!;
         if ($git_url =~ /github\.com/) {
+            if ( $git_url !~ /\@github/ ) {
+                $git_url =~ s/github\.com/git\@github.com/;
+            }
             my $http_url = $git_url;
             $http_url =~ s![\w\-]+\@([^:]+):!https://$1/!;
             $http_url =~ s!\Agit://!https://!;


### PR DESCRIPTION
the git remote url doesn't have to contain a user name before the hostname.
For example, when you have a github.com host defined in your ssh config,
ssh will find the username in the ssh config file.

Thus I made the 'user@' part optional when parsing the output of git remote show
and when the URL is detected to be a github.com URL, the 'git@' part is added
when it isn't already there.
