### PR TITLE
now correspond to a badge of Gitter

### DIFF
--- a/lib/Minilla.pm
+++ b/lib/Minilla.pm
@@ -199,9 +199,9 @@ See L<CPAN::Meta::Spec>.
 
 =item badges
 
-    badges = ['travis', 'coveralls']
+    badges = ['travis', 'coveralls', 'gitter']
 
-Embed badges image (e.g. Travis-CI) to README.md. It ought to be array and each elements must be service name. Now, supported services are only 'travis' and 'coveralls'.
+Embed badges image (e.g. Travis-CI) to README.md. It ought to be array and each elements must be service name. Now, supported services are only 'travis', 'coveralls' and 'gitter'.
 
 =item PL_files
 

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -590,6 +590,9 @@ sub regenerate_readme_md {
                 if ($badge eq 'coveralls') {
                     push @badges, "[![Coverage Status](https://coveralls.io/repos/$user_name/$repository_name/badge.png?branch=master)](https://coveralls.io/r/$user_name/$repository_name?branch=master)"
                 }
+                if ($badge eq 'gitter') {
+                    push @badges, "[![Gitter chat](https://badges.gitter.im/$user_name/$repository_name.png)](https://gitter.im/$user_name/$repository_name)";
+                }
             }
         }
 

--- a/t/project/badge.t
+++ b/t/project/badge.t
@@ -38,14 +38,18 @@ subtest 'Badge' => sub {
     subtest 'Badges exist' => sub {
         write_minil_toml({
             name   => 'Acme-Foo',
-            badges => ['travis', 'coveralls'],
+            badges => ['travis', 'coveralls', 'gitter'],
         });
         $project->regenerate_files;
 
         open my $fh, '<', 'README.md';
         ok chomp (my $got = <$fh>);
 
-        my $badge_markdowns = ["[![Build Status](https://travis-ci.org/tokuhirom/Minilla.png?branch=master)](https://travis-ci.org/tokuhirom/Minilla)", "[![Coverage Status](https://coveralls.io/repos/tokuhirom/Minilla/badge.png?branch=master)](https://coveralls.io/r/tokuhirom/Minilla?branch=master)"];
+        my $badge_markdowns = [
+            "[![Build Status](https://travis-ci.org/tokuhirom/Minilla.png?branch=master)](https://travis-ci.org/tokuhirom/Minilla)",
+            "[![Coverage Status](https://coveralls.io/repos/tokuhirom/Minilla/badge.png?branch=master)](https://coveralls.io/r/tokuhirom/Minilla?branch=master)",
+            "[![Gitter chat](https://badges.gitter.im/tokuhirom/Minilla.png)](https://gitter.im/tokuhirom/Minilla)",
+        ];
         my $expected = join(' ', @$badge_markdowns);
         is $got, $expected;
     };


### PR DESCRIPTION
I wanna display a [Gitter](https://gitter.im) badge on README.md via TOML.
