### PR TITLE
Work with ssh:// scheme

### DIFF
--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -470,7 +470,7 @@ sub extract_git_info {
     if ( `git remote show -n origin` =~ /URL: (.*)$/m && $1 ne 'origin' ) {
         # XXX Make it public clone URL, but this only works with github
         my $git_url = $1;
-        $git_url =~ s!\A(?:ssh://)?[\w\-]+@([^:]+):!git://$1/!; # git@github.com:xxx/yyy -> git://github.com/xxx/yyy
+        $git_url =~ s!\A(?:ssh://)?[\w\-]+@([^:]+)[:/]!git://$1/!; # git@github.com:xxx/yyy -> git://github.com/xxx/yyy
         $git_url =~ s!\Ahttps?://!git://!; # https:// or http:// -> git://
 
         if ($git_url =~ /github\.com/) {

--- a/t/project/meta.t
+++ b/t/project/meta.t
@@ -116,7 +116,7 @@ subtest 'resources' => sub {
         $resources_url_of_meta_json_ok->($git_conf_url);
     };
     subtest 'when remote of origin url is ssh with ssh scheme' => sub {
-        my $git_conf_url = 'ssh://git@github.com:tokuhirom/Minilla.git';
+        my $git_conf_url = 'ssh://git@github.com/tokuhirom/Minilla.git';
         $resources_url_of_meta_json_ok->($git_conf_url);
     };
 };


### PR DESCRIPTION
For watever reason, when I clone my repositories I get a repository url
qualified with the ssh:// scheme, which Minilla doesn't seem to expect:

```
   url = ssh://git@github.com/lestrrat/Data-Localize.git
```

This creats all sorts of havoc in the META.json resources section:

```
   "resources" : {
      "bugtracker" : {
         "web" : "https://ssh///git@github.com/lestrrat/Data-Localize/issues"
      },
      "homepage" : "https://ssh///git@github.com/lestrrat/Data-Localize",
      "repository" : {
         "type" : "git",
         "url" : "git://ssh///git@github.com/lestrrat/Data-Localize.git",
         "web" : "https://ssh///git@github.com/lestrrat/Data-Localize"
      }
   },
```

This change fixes this by checking for the ssh:// scheme when stripping
git@ username from github repository URLs
