### PR TITLE
Work better with github urls

### DIFF
--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -493,8 +493,6 @@ sub extract_git_info {
         } else {
             # normal repository
             if ($registered_url !~ m{^file://}) {
-                $registered_url =~ s!\A[\w\-]+@([^:]+):!git://$1/!; # git@github.com:xxx/yyy -
-                $registered_url =~ s!\Ahttps?://!git://!; # https:// or http:// -> git://
                 $repository = +{
                     url => $registered_url,
                 };


### PR DESCRIPTION
This is a retake of pr #145, but using a different approach. For
reference the original commit message from
7eabe9c296c324fc384f5ace1bf3eeeb67981928 is copied here:

For watever reason, when I clone my repositories I get a repository url
qualified with the ssh:// scheme, which Minilla doesn't seem to expect:

```
   url = ssh://git@github.com/lestrrat/Data-Localize.git
```

This creats all sorts of havoc in the META.json resources section:

```
   "resources" : {
      "bugtracker" : {
         "web" :
"https://ssh///git@github.com/lestrrat/Data-Localize/issues"
      },
      "homepage" :
"https://ssh///git@github.com/lestrrat/Data-Localize",
      "repository" : {
         "type" : "git",
         "url" :
"git://ssh///git@github.com/lestrrat/Data-Localize.git",
         "web" : "https://ssh///git@github.com/lestrrat/Data-Localize"
      }
   },
```

This change fixes this by checking for the ssh:// scheme when stripping
git@ username from github repository URLs
