### PR TITLE
Gathers files on submodule recursive. And fixed the issue that occurs when multiple submodules contains.

### DIFF
--- a/lib/Minilla/Git.pm
+++ b/lib/Minilla/Git.pm
@@ -55,7 +55,12 @@ sub git_submodules {
 sub git_submodule_files {
     # XXX: `git ls-files -z` does *NOT* print new line in last.
     #      So it breaks format when multiple submodules contains and combined with `git submodule foreach`. (and failed to parse.)
-    my @output = split /\n/, `git submodule foreach --recursive $^X -e 'system "git ls-files -z"; print "\n"'`;
+    my @output = split /\n/, `git submodule foreach --recursive git ls-files -z`;
+    for (my $i = 1; $i <= @output-2; $i += 2) {
+        $output[$i] =~ s/\0([^\0]*)$//;
+        splice @output, $i+1, 0, $1;
+    }
+
     my @files;
     while (@output) {
         my $submodule_line = shift @output;

--- a/lib/Minilla/Git.pm
+++ b/lib/Minilla/Git.pm
@@ -43,7 +43,7 @@ sub git_submodule_add {
 }
 
 sub git_submodules {
-    my @submodules = split /\n/, `git submodule status`;
+    my @submodules = split /\n/, `git submodule status --recursive`;
     my @files;
     for (@submodules) {
         my ($path) = $_ =~ /^[+\-U\x20][0-9a-f]{40}\x20([^\x20]+).*$/;
@@ -53,7 +53,7 @@ sub git_submodules {
 }
 
 sub git_submodule_files {
-    my @output = split /\n/, `git submodule foreach git ls-files -z`;
+    my @output = split /\n/, `git submodule foreach --recursive git ls-files -z`;
     my @files;
     while (@output) {
         my $submodule_line = shift @output;

--- a/lib/Minilla/Git.pm
+++ b/lib/Minilla/Git.pm
@@ -53,7 +53,9 @@ sub git_submodules {
 }
 
 sub git_submodule_files {
-    my @output = split /\n/, `git submodule foreach --recursive git ls-files -z`;
+    # XXX: `git ls-files -z` does *NOT* print new line in last.
+    #      So it breaks format when multiple submodules contains and combined with `git submodule foreach`. (and failed to parse.)
+    my @output = split /\n/, `git submodule foreach --recursive $^X -e 'system "git ls-files -z"; print "\n"'`;
     my @files;
     while (@output) {
         my $submodule_line = shift @output;

--- a/t/filegatherer.t
+++ b/t/filegatherer.t
@@ -20,7 +20,7 @@ subtest 'FileGatherer' => sub {
             exclude_match => ['^local/'],
         )->gather_files('.');
 
-        is(join(',', sort @files), 'META.json,README,foo,libfoo/foo.c');
+        is(join(',', sort @files), 'META.json,README,foo,libbar/bar.c,libfoo/foo.c');
     };
 
     subtest include_dotfiles => sub {
@@ -29,7 +29,7 @@ subtest 'FileGatherer' => sub {
             include_dotfiles => 1,
         )->gather_files('.');
 
-        is(join(',', sort @files), '.dot/dot,.gitignore,.gitmodules,META.json,README,foo,libfoo/foo.c,xtra/.dot,xtra/.dotdir/dot');
+        is(join(',', sort @files), '.dot/dot,.gitignore,.gitmodules,META.json,README,foo,libbar/bar.c,libfoo/foo.c,xtra/.dot,xtra/.dotdir/dot');
     };
 
     subtest 'MANIFEST.SKIP' => sub {
@@ -40,7 +40,7 @@ subtest 'FileGatherer' => sub {
             exclude_match => ['^local/'],
         )->gather_files('.');
 
-        is(join(',', sort @files), 'MANIFEST.SKIP,META.json,README,libfoo/foo.c');
+        is(join(',', sort @files), 'MANIFEST.SKIP,META.json,README,libbar/bar.c,libfoo/foo.c');
     };
 };
 
@@ -48,7 +48,7 @@ done_testing;
 
 sub init {
     my $guard = pushd(tempdir());
-    my $submodule_repo = create_submodule_repo();
+    my %submodule_repos = map { $_ => create_submodule_repo($_) } qw/foo bar/;
 
     mkdir 'local';
     mkdir '.dot';
@@ -66,17 +66,19 @@ sub init {
 
     git_init();
     git_add('.');
-    git_submodule_add("file://$submodule_repo", 'libfoo');
+    git_submodule_add("file://$submodule_repos{$_}", "lib$_") for keys %submodule_repos;
     git_commit('-m', 'foo');
 
     $guard;
 }
 
 sub create_submodule_repo {
+    my $name = shift;
+
     my $dir = tempdir();
     my $guard = pushd($dir);
 
-    spew('foo.c', '...');
+    spew("$name.c", '...');
     git_init();
     git_add('.');
     git_commit('-m', 'submodule');

--- a/t/filegatherer/submodules-recursive.t
+++ b/t/filegatherer/submodules-recursive.t
@@ -1,0 +1,103 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use t::Util;
+use File::Temp qw(tempdir);
+use File::pushd;
+
+use Minilla::Util qw(spew);
+use Minilla::FileGatherer;
+use Minilla::Git;
+
+can_ok('Minilla::FileGatherer', 'new');
+
+subtest 'FileGatherer' => sub {
+    my $guard = init();
+
+    subtest 'normal' => sub {
+        my @files = Minilla::FileGatherer->new(
+            exclude_match => ['^local/'],
+        )->gather_files('.');
+
+        is(join(',', sort @files), 'META.json,README,foo,libbar/bar.c,libbar/libbar/bar.c,libbar/libfoo/foo.c,libfoo/foo.c,libfoo/libbar/bar.c,libfoo/libfoo/foo.c');
+    };
+
+    subtest include_dotfiles => sub {
+        my @files = Minilla::FileGatherer->new(
+            exclude_match => ['^local/'],
+            include_dotfiles => 1,
+        )->gather_files('.');
+
+        is(join(',', sort @files), '.dot/dot,.gitignore,.gitmodules,META.json,README,foo,libbar/.gitmodules,libbar/bar.c,libbar/libbar/bar.c,libbar/libfoo/foo.c,libfoo/.gitmodules,libfoo/foo.c,libfoo/libbar/bar.c,libfoo/libfoo/foo.c,xtra/.dot,xtra/.dotdir/dot');
+    };
+
+    subtest 'MANIFEST.SKIP' => sub {
+        spew('MANIFEST.SKIP', q{^foo$});
+        git_init_add_commit();
+
+        my @files = Minilla::FileGatherer->new(
+            exclude_match => ['^local/'],
+        )->gather_files('.');
+
+        is(join(',', sort @files), 'MANIFEST.SKIP,META.json,README,libbar/bar.c,libbar/libbar/bar.c,libbar/libfoo/foo.c,libfoo/foo.c,libfoo/libbar/bar.c,libfoo/libfoo/foo.c');
+    };
+};
+
+done_testing;
+
+sub init {
+    my $guard = pushd(tempdir());
+    my %submodule_repos = map { $_ => create_deep_submodule_repo($_) } qw/foo bar/;
+
+    mkdir 'local';
+    mkdir '.dot';
+    mkpath 'xtra/.dotdir';
+    mkpath 'extlib/lib';
+    spew('local/foo', '...');
+    spew('extlib/lib/Foo.pm', '...');
+    spew('.gitignore', '...');
+    spew('README', 'rrr');
+    spew('META.json', 'mmm');
+    spew('foo', 'mmm');
+    spew('.dot/dot', 'dot');
+    spew('xtra/.dot', 'dot');
+    spew('xtra/.dotdir/dot', '...');
+
+    git_init();
+    git_add('.');
+    git_submodule_add("file://$submodule_repos{$_}", "lib$_") for keys %submodule_repos;
+    system 'git submodule update --init --recursive';
+    git_commit('-m', 'foo');
+
+    $guard;
+}
+
+sub create_deep_submodule_repo {
+    my $name = shift;
+
+    my $dir = create_submodule_repo($name);
+    my $guard = pushd($dir);
+
+    my %submodule_repos = map { $_ => create_submodule_repo($_) } qw/foo bar/;
+
+    git_add('.');
+    git_submodule_add("file://$submodule_repos{$_}", "lib$_") for keys %submodule_repos;
+    git_commit('-m', 'deep submodule');
+
+    return $dir;
+}
+
+sub create_submodule_repo {
+    my $name = shift;
+
+    my $dir = tempdir();
+    my $guard = pushd($dir);
+
+    spew("$name.c", '...');
+    git_init();
+    git_add('.');
+    git_commit('-m', 'submodule');
+
+    return $dir;
+}


### PR DESCRIPTION
Isses:
* Could not solve the recursive submodule.
* Outputting the incorrect results when multiple submodules contains.

Solutions:
* Gathers files on submodule recursive.
* Fix to required format when multiple submodules contains.

`git ls-files -z` does *NOT* print new line in last.
So it breaks format when multiple submodules contains and combined with `git submodule foreach`. (and failed to parse.)