### PR TITLE
tiny fixes for ExtUtils::MakeMaker

### DIFF
--- a/lib/Minilla/CLI/Clean.pm
+++ b/lib/Minilla/CLI/Clean.pm
@@ -26,6 +26,8 @@ sub run {
         'MYMETA.yml',
         '_build_params',
         '_build',       # M::B
+        'Makefile',
+        'pm_to_blib',
     );
     print("Would remove $_\n") for (@targets);
     if ($yes_opt || prompt('Remove it?', 'y') =~ /y/i) {

--- a/lib/Minilla/Profile/Base.pm
+++ b/lib/Minilla/Profile/Base.pm
@@ -198,6 +198,7 @@ Revision history for Perl extension <% $dist %>
 /Build.bat
 /blib
 /Makefile
+/pm_to_blib
 
 /carton.lock
 /.carton/


### PR DESCRIPTION
* ExtUtils::MakeMaker creates `pm_to_blib` file, so ignore it.
* `minil clean` cleans `Makefile` and `pm_to_blib` too.