### PR TITLE
add missing EXE_FILES attribute for EU::MM

### DIFF
--- a/lib/Minilla/ModuleMaker/ExtUtilsMakeMaker.pm
+++ b/lib/Minilla/ModuleMaker/ExtUtilsMakeMaker.pm
@@ -106,6 +106,7 @@ my %WriteMakefileArgs = (
     NAME     => '<?= $project->name ?>',
     DISTNAME => '<?= $project->dist_name ?>',
     VERSION  => '<?= $project->version ?>',
+    EXE_FILES => [<?= $project->script_files ?>],
     CONFIGURE_REQUIRES => <?= $d->('configure') ?>,
     BUILD_REQUIRES     => <?= $d->('build') ?>,
     TEST_REQUIRES      => <?= $d->('test') ?>,


### PR DESCRIPTION
Executable files would not be installed unless we specify them in EXE_FILES attribute.