### PR TITLE
silence test warnings relating to git log

### DIFF
--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -630,6 +630,8 @@ sub verify_prereqs {
 sub _build_contributors {
     my $self = shift;
 
+    return [] unless (`git show-ref --head`);
+
     my $normalize = sub {
         local $_ = shift;
         if (/<([^>]+)>/) {


### PR DESCRIPTION
 * The contributors list is generated by parsing the output of `git
   log`. Calling `git log` on a repository with no commits produces the
   message "fatal: bad default revision 'HEAD'".  Check to see if HEAD
   exists before trying to generate the contributors.  If no HEAD,
   return an empty array.