### PR TITLE
add markdown_maker config key

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -37,6 +37,7 @@ requires 'Moo' => 1.001000;
 # Utilities
 requires 'Data::Section::Simple' => 0.04;
 requires 'Term::ANSIColor';
+requires 'Module::Runtime';
 
 # Modules required by minil new/minil dist/minil release are optional.
 # It's good for contributors

--- a/lib/Minilla.pm
+++ b/lib/Minilla.pm
@@ -322,6 +322,13 @@ If you set this key false, Minilla will not generate 'xt/minilla/minimum_version
 The C<requires_external_bin> command takes the name of a system command
 or program. Build fail if the command does not exist.
 
+=item markdown_maker
+
+    markdown_maker = "Pod::Markdown::Github"
+
+Use a different module to generate C<README.md> from your pod. This
+module must subclass L<Pod::Markdown>.
+
 =back
 
 =head1 FAQ


### PR DESCRIPTION
 * README.md is generated from your pod by Pod::Markdown.  You can
   use a different module, such as Pod::Markdown::Github, by setting the
   markdown_maker in your minil.toml.  The module must be a subclass of Pod::Markdown.