### PR TITLE
Use Module::Build::Tiny as a default module maker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: perl
 before_script:
   - "git config --global user.email 'you@example.com'"
   - "git config --global user.name 'Your Name'"
+install:
+  - cpanm -nq --installdeps --with-develop --with-recommends .
 perl:
   - "5.20"
   - "5.18"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,3 @@ perl:
   - 5.12
   - "5.10"
   - 5.8
-before_install:
-  cpanm -n Devel::Cover::Report::Coveralls
-script:
-  perl Build.PL && ./Build build && cover -test
-after_success:
-  cover -report coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: perl
 before_script:
   - "git config --global user.email 'you@example.com'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,13 @@ before_script:
   - "git config --global user.email 'you@example.com'"
   - "git config --global user.name 'Your Name'"
 perl:
+  - "5.20"
+  - "5.18"
   - 5.16
   - 5.14
+  - 5.12
+  - "5.10"
+  - 5.8
 before_install:
   cpanm -n Devel::Cover::Report::Coveralls
 script:

--- a/Build.PL
+++ b/Build.PL
@@ -4,63 +4,9 @@
 # =========================================================================
 
 use 5.008_001;
-
 use strict;
-use warnings;
-use utf8;
 
-use Module::Build;
-use File::Basename;
-use File::Spec;
+use Module::Build::Tiny 0.035;
 
-my %args = (
-    license              => 'perl',
-    dynamic_config       => 0,
-
-    configure_requires => {
-        'Module::Build' => 0.38,
-    },
-
-    name            => 'Minilla',
-    module_name     => 'Minilla',
-    allow_pureperl => 0,
-
-    script_files => [glob('script/*'), glob('bin/*')],
-    c_source     => [qw()],
-    PL_files => {},
-
-    test_files           => ((-d '.git' || $ENV{RELEASE_TESTING}) && -d 'xt') ? 't/ xt/' : 't/',
-    recursive_test_files => 1,
-
-    tap_harness_args => {"jobs" => 3},
-
-);
-if (-d 'share') {
-    $args{share_dir} = 'share';
-}
-
-my $builder = Module::Build->subclass(
-    class => 'MyBuilder',
-    code => q{
-        sub ACTION_distmeta {
-            die "Do not run distmeta. Install Minilla and `minil install` instead.\n";
-        }
-        sub ACTION_installdeps {
-            die "Do not run installdeps. Run `cpanm --installdeps .` instead.\n";
-        }
-    }
-)->new(%args);
-$builder->create_build_script();
-
-use File::Copy;
-
-print "cp META.json MYMETA.json\n";
-copy("META.json","MYMETA.json") or die "Copy failed(META.json): $!";
-
-if (-f 'META.yml') {
-    print "cp META.yml MYMETA.yml\n";
-    copy("META.yml","MYMETA.yml") or die "Copy failed(META.yml): $!";
-} else {
-    print "There is no META.yml... You may install this module from the repository...\n";
-}
+Build_PL();
 

--- a/META.json
+++ b/META.json
@@ -28,7 +28,6 @@
    "prereqs" : {
       "configure" : {
          "requires" : {
-            "Module::Build" : "0",
             "Module::Build::Tiny" : "0.035"
          }
       },

--- a/META.json
+++ b/META.json
@@ -4,7 +4,7 @@
       "Tokuhiro Matsuno < tokuhirom@gmail.com >"
    ],
    "dynamic_config" : 0,
-   "generated_by" : "Minilla/v2.4.0, CPAN::Meta::Converter version 2.141520",
+   "generated_by" : "Minilla/v2.4.1, CPAN::Meta::Converter version 2.150005",
    "license" : [
       "perl_5"
    ],
@@ -28,7 +28,8 @@
    "prereqs" : {
       "configure" : {
          "requires" : {
-            "Module::Build" : "0.38"
+            "Module::Build" : "0",
+            "Module::Build::Tiny" : "0.035"
          }
       },
       "develop" : {
@@ -65,6 +66,7 @@
             "Getopt::Long" : "2.36",
             "Module::CPANfile" : "0.9025",
             "Module::Metadata" : "1.000027",
+            "Module::Runtime" : "0",
             "Moo" : "1.001",
             "Pod::Markdown" : "1.322",
             "TAP::Harness::Env" : "0",
@@ -143,10 +145,12 @@
       "Daisuke Maki <lestrrat+github@gmail.com>",
       "Klaus Eichner <klaus03@gmail.com>",
       "Syohei YOSHIDA <syohex@gmail.com>",
+      "moznion <moznion@gmail.com>",
       "karupanerura <karupa@cpan.org>",
       "Shoichi Kaji <skaji@cpan.org>",
-      "moznion <moznion@gmail.com>",
-      "Tatsuhiko Miyagawa <miyagawa@bulknews.net>",
-      "tokuhirom <tokuhirom@gmail.com>"
-   ]
+      "Fitz Elliott <felliott@fiskur.org>",
+      "tokuhirom <tokuhirom@gmail.com>",
+      "Tatsuhiko Miyagawa <miyagawa@bulknews.net>"
+   ],
+   "x_serialization_backend" : "JSON::PP version 2.27300"
 }

--- a/README.md
+++ b/README.md
@@ -293,6 +293,13 @@ But, you can write configurations to _minil.toml_ file in [TOML](https://github.
     The `requires_external_bin` command takes the name of a system command
     or program. Build fail if the command does not exist.
 
+- markdown\_maker
+
+        markdown_maker = "Pod::Markdown::Github"
+
+    Use a different module to generate `README.md` from your pod. This
+    module must subclass [Pod::Markdown](https://metacpan.org/pod/Pod::Markdown).
+
 # FAQ
 
 - How can I manage **contributors** section?
@@ -327,7 +334,7 @@ But, you can write configurations to _minil.toml_ file in [TOML](https://github.
 
 - How can I install script files?
 
-    Your executables must be in `script/`. It's [Module::Build::Tiny](https://metacpan.org/pod/Module::Build::Tiny)'s rule.
+    Your executables must be in `script/` directory.
 
 - How to switch from Module::Install/Module::Build/Dist::Zilla?
 
@@ -342,23 +349,24 @@ But, you can write configurations to _minil.toml_ file in [TOML](https://github.
 
 - How do I use Module::Build::Tiny with Minilla?
 
-    Minilla v0.15.0+ supports v0.15.0(EXPERIMENTAL).
+    Minilla supports Module::Build::Tiny and uses it as a default installer since v1.0.0.
 
-    If you want to create new project with Module::Build::Tiny, run the command as following.
-
-        % minil new -p ModuleBuildTiny My::Awesome::Module
-
-    If you want to migrate existing project, you need to rewrite minil.toml file.
-    You need to add following line:
+    If you want to migrate an existing project created before Minilla v1.0, you need to rewrite `minil.toml` file.
+    You need to add the following line:
 
         module_maker="ModuleBuildTiny"
+
+- How do I use Module::Build with Minilla?
+
+    If you want to create new project with Module::Build, run the command as following.
+
+        % minil new -p ModuleBuild My::Awesome::Module
 
 - How do I use ExtUtils::MakeMaker with Minilla?
 
     Minilla v2.1.0+ supports EUMM(EXPERIMENTAL).
 
-    You need to rewrite minil.toml file.
-    You need to add following line:
+    You need to rewrite minil.toml file and add the following line:
 
         module_maker="ExtUtilsMakeMaker"
 

--- a/cpanfile
+++ b/cpanfile
@@ -71,10 +71,6 @@ on 'test' => sub {
     requires 'Module::Build::Tiny', 0.035; # https://github.com/tokuhirom/Minilla/issues/151
 };
 
-on 'configure' => sub {
-    requires 'Module::Build';
-};
-
 on 'develop' => sub {
     # Dependencies for developers
 };

--- a/lib/Minilla.pm
+++ b/lib/Minilla.pm
@@ -36,10 +36,6 @@ Minilla is a CPAN module authoring tool. Minilla provides L<minil> command for a
 
     (M::I - inc) + shipit + (dzil - plugins)
 
-B<THIS IS A DEVELOPMENT RELEASE. API MAY CHANGE WITHOUT NOTICE>.
-
-=head1 MOTIVATION
-
 =head1 CONVENTION
 
 As stated above, Minilla is opinionated. Minilla has a bold assumption and convention like the followings, which are almost compatible to the sister project L<Dist::Milla>.

--- a/lib/Minilla.pm
+++ b/lib/Minilla.pm
@@ -367,7 +367,7 @@ Is there a reason to remove ppport.h from repo?
 
 =item How can I install script files?
 
-Your executables must be in F<script/>. It's L<Module::Build::Tiny>'s rule.
+Your executables must be in F<script/> directory.
 
 =item How to switch from Module::Install/Module::Build/Dist::Zilla?
 
@@ -382,23 +382,24 @@ You can use MANIFEST.SKIP file for ignoring files. ref. L<ExtUtils::Manifest>.
 
 =item How do I use Module::Build::Tiny with Minilla?
 
-Minilla v0.15.0+ supports v0.15.0(EXPERIMENTAL).
+Minilla supports Module::Build::Tiny and uses it as a default installer since v1.0.0.
 
-If you want to create new project with Module::Build::Tiny, run the command as following.
-
-    % minil new -p ModuleBuildTiny My::Awesome::Module
-
-If you want to migrate existing project, you need to rewrite minil.toml file.
-You need to add following line:
+If you want to migrate an existing project created before Minilla v1.0, you need to rewrite C<minil.toml> file.
+You need to add the following line:
 
     module_maker="ModuleBuildTiny"
+
+=item How do I use Module::Build with Minilla?
+
+If you want to create new project with Module::Build, run the command as following.
+
+    % minil new -p ModuleBuild My::Awesome::Module
 
 =item How do I use ExtUtils::MakeMaker with Minilla?
 
 Minilla v2.1.0+ supports EUMM(EXPERIMENTAL).
 
-You need to rewrite minil.toml file.
-You need to add following line:
+You need to rewrite minil.toml file and add the following line:
 
     module_maker="ExtUtilsMakeMaker"
 

--- a/lib/Minilla/Migrate.pm
+++ b/lib/Minilla/Migrate.pm
@@ -54,6 +54,8 @@ sub run {
 
     if (-f 'dist.ini') {
         $self->dist_ini2minil_toml();
+    } elsif (!-f 'minil.toml') {
+        $self->project->generate_minil_toml('Default');
     }
 
     $self->remove_unused_files();

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -225,10 +225,33 @@ sub config {
         if ($err) {
             errorf("TOML error in %s: %s\n", $toml_path, $err);
         }
+        $self->_patch_config_for_mb($conf) unless $conf->{module_maker};
         $conf;
     } else {
         +{};
     }
+}
+
+sub _patch_config_for_mb {
+    my($self, $conf) = @_;
+
+    if (exists $conf->{build} or exists $conf->{XSUtil}) {
+        warn <<WARN unless $self->{__already_warned}++;
+!
+! WARNING:
+! module_maker is not set in your Minilla config (minil.toml), but found [build] or [XSUtil] section in it.
+! Defaulting to Module::Build, but you're suggested to add the following to your minil.toml:
+!
+!   module_maker="ModuleBuild"
+!
+! This friendly warning will go away in the next major release, and Minilla will default to ModuleBuildTiny
+! when module_maker is not explicitly set in minil.toml.
+!
+WARN
+        $conf->{module_maker} = "ModuleBuild";
+    }
+
+    return;
 }
 
 sub c_source {

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -43,7 +43,7 @@ has module_maker => (
             $klass = $klass =~ s/^\+// ? $klass : "Minilla::ModuleMaker::$klass";
             return $klass->new();
         }
-        Minilla::ModuleMaker::ModuleBuild->new()
+        Minilla::ModuleMaker::ModuleBuildTiny->new()
     },
     lazy => 1,
 );

--- a/minil.toml
+++ b/minil.toml
@@ -1,5 +1,3 @@
 name="Minilla"
 authority = "cpan:TOKUHIROM"
-
-[tap_harness_args]
-jobs=3
+module_maker = "ModuleBuildTiny"

--- a/t/cli/regenerate_BuildPL.t
+++ b/t/cli/regenerate_BuildPL.t
@@ -29,6 +29,7 @@ sub regenerate_BuildPL_test {
 
         write_minil_toml({
             name  => 'Acme-Foo',
+            module_maker => "ModuleBuild",
             build => { build_class => "builder::MyBuilder" }
         });
 

--- a/t/dist/Acme-FooXS.dat
+++ b/t/dist/Acme-FooXS.dat
@@ -584,6 +584,8 @@ The End
 
 ==> minil.toml <==
 
+module_maker = "ModuleBuild"
+
 [build]
 build_class = "builder::MyBuilder"
 

--- a/t/module_maker/PL_files.t
+++ b/t/module_maker/PL_files.t
@@ -32,6 +32,7 @@ sub test {
 ...
     write_minil_toml({
         name => 'Acme-Foo',
+        module_maker => "ModuleBuild",
         PL_files => {
             foo => 'bar',
         },

--- a/t/module_maker/allow_pureperl.t
+++ b/t/module_maker/allow_pureperl.t
@@ -40,6 +40,7 @@ sub test {
 ...
     write_minil_toml({
         name => 'Acme-Foo',
+        module_maker => "ModuleBuild",
         allow_pureperl => $allow,
     });
     git_init_add_commit();

--- a/t/module_maker/c_source.t
+++ b/t/module_maker/c_source.t
@@ -32,6 +32,7 @@ sub test {
 ...
     write_minil_toml({
         name => 'Acme-Foo',
+        module_maker => "ModuleBuild",
         c_source => ['src'],
     });
     git_init_add_commit();

--- a/t/module_maker/tap_harness_args.t
+++ b/t/module_maker/tap_harness_args.t
@@ -33,6 +33,7 @@ sub test {
 
     write_minil_toml({
         name => 'Acme-Foo',
+        module_maker => "ModuleBuild",
         tap_harness_args => {
             jobs => 9,
         },

--- a/t/module_maker/xsutil.t
+++ b/t/module_maker/xsutil.t
@@ -74,6 +74,7 @@ sub test {
     write_minil_toml(
         {   name   => 'Acme-Foo',
             XSUtil => $xsutil,
+            module_maker => "ModuleBuild",
         }
     );
     git_init_add_commit();

--- a/t/project/xsutil.t
+++ b/t/project/xsutil.t
@@ -31,6 +31,7 @@ subtest 'Use XSUtil with default value' => sub {
     make_profile();
     write_minil_toml(
         {   name   => 'Acme-Foo',
+            module_maker => "ModuleBuild",
             XSUtil => {},
         }
     );
@@ -51,6 +52,7 @@ subtest 'Use XSUtil with specify value' => sub {
     make_profile();
     write_minil_toml(
         {   name   => 'Acme-Foo',
+            module_maker => "ModuleBuild",
             XSUtil => {
                 needs_compiler_c99 => 1,
                 needs_compiler_cpp => 1,


### PR DESCRIPTION
Even when minil.toml does not exist or module_maker is not set, make sure to use MBT by default.

There's a backward compat detector so that if custom builder or XSUtil options are set in minil.toml, it falls back to ModuleBuild with a big warning suggesting to set `module_maker` in the config file.

It also makes sure `minil.toml` is created in `minil migrate`, unlike only when there's a dist.ini file.

This switches Minilla itself to use MBT as well.

Fixes #164 
