### PR TITLE
Require newer MB/MM and remove the hack in build script

### DIFF
--- a/lib/Minilla/ModuleMaker/ExtUtilsMakeMaker.pm
+++ b/lib/Minilla/ModuleMaker/ExtUtilsMakeMaker.pm
@@ -36,7 +36,7 @@ sub prereqs {
     my ($self, $project) = @_;
 
     my %configure_requires = (
-        'ExtUtils::MakeMaker' => '0',
+        'ExtUtils::MakeMaker' => '6.64', # TEST_REQUIRES (and MYMETA)
     );
 
     my $prereqs = +{
@@ -89,7 +89,7 @@ __DATA__
 use 5.008_001;
 use strict;
 
-use ExtUtils::MakeMaker;
+use ExtUtils::MakeMaker 6.64;
 
 ? if ( @{ $project->requires_external_bin || [] } ) {
 use Devel::CheckBin;
@@ -112,23 +112,5 @@ my %WriteMakefileArgs = (
     TEST_REQUIRES      => <?= $d->('test') ?>,
     PREREQ_PM          => <?= $d->('runtime') ?>,
 );
-
-my $full_prereqs = <?= Dumper($prereqs->merged_requirements([qw(configure build runtime test)])->as_string_hash) ?>;
-
-unless (eval { ExtUtils::MakeMaker->VERSION(6.63_03) }) {
-    delete $WriteMakefileArgs{TEST_REQUIRES};
-    delete $WriteMakefileArgs{BUILD_REQUIRES};
-    $WriteMakefileArgs{PREREQ_PM} = $full_prereqs;
-}
-
-unless (eval { ExtUtils::MakeMaker->VERSION(6.52) }) {
-    delete $WriteMakefileArgs{CONFIGURE_REQUIRES};
-}
-
-unless (eval { ExtUtils::MakeMaker->VERSION(6.57_01) }) {
-    use File::Copy;
-    copy('META.yml', 'MYMETA.yml')   or warn "META.yml: $!";
-    copy('META.json', 'MYMETA.json') or warn "META.json: $!";
-}
 
 WriteMakefile(%WriteMakefileArgs);

--- a/lib/Minilla/ModuleMaker/ModuleBuild.pm
+++ b/lib/Minilla/ModuleMaker/ModuleBuild.pm
@@ -34,7 +34,7 @@ sub prereqs {
     Carp::croak('Usage: $module_maker->prereqs($project)') unless defined $project;
 
     my %configure_requires = (
-        'Module::Build'       => $project->module_build_version,
+        'Module::Build'       => 0.4005, # test_requires, --pureperl
     );
     if ($project->requires_external_bin && @{$project->requires_external_bin}) {
         $configure_requires{'Devel::CheckBin'} = 0;
@@ -49,7 +49,6 @@ sub prereqs {
     };
 
     if( $project->use_xsutil ){
-        delete $prereqs->{configure}{requires}{'Module::Build'};
         $prereqs->{configure}{requires}{'Module::Build::XSUtil'} = '0.03';
     }
     return $prereqs;
@@ -93,7 +92,7 @@ my %args = (
     dynamic_config       => 0,
 
     configure_requires => {
-        'Module::Build' => <?= $project->module_build_version ?>,
+        'Module::Build' => '0.4005',
     },
 
     name            => '<?= $project->dist_name ?>',
@@ -135,16 +134,4 @@ my $builder = <?= $project->build_class ?>->subclass(
     }
 )->new(%args);
 $builder->create_build_script();
-
-use File::Copy;
-
-print "cp META.json MYMETA.json\n";
-copy("META.json","MYMETA.json") or die "Copy failed(META.json): $!";
-
-if (-f 'META.yml') {
-    print "cp META.yml MYMETA.yml\n";
-    copy("META.yml","MYMETA.yml") or die "Copy failed(META.yml): $!";
-} else {
-    print "There is no META.yml... You may install this module from the repository...\n";
-}
 

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -111,12 +111,6 @@ sub allow_pureperl {
     $self->config->{allow_pureperl} ? 1 : 0;
 }
 
-sub module_build_version {
-    my $self = shift;
-    # --pureperl-only support was added in 0.4005
-    $self->allow_pureperl ? 0.4005 : 0.38;
-}
-
 sub version {
     my $self = shift;
     my $version = $self->config->{version} || $self->metadata->version;

--- a/t/module_maker/allow_pureperl.t
+++ b/t/module_maker/allow_pureperl.t
@@ -10,12 +10,12 @@ use Minilla::Project;
 test(1, sub {
     my $build_pl = slurp('Build.PL');
     like($build_pl, qr{allow_pureperl\s+=>\s+1});
-    like($build_pl, qr{'Module::Build'\s+=>\s+0\.4005});
+    like($build_pl, qr{'Module::Build'\s+=>\s+'0\.4005'});
 });
 test(0, sub {
     my $build_pl = slurp('Build.PL');
     like($build_pl, qr{allow_pureperl\s+=>\s+0});
-    like($build_pl, qr{'Module::Build'\s+=>\s+0\.38});
+    like($build_pl, qr{'Module::Build'\s+=>\s+'0\.4005'});
 });
 
 done_testing;


### PR DESCRIPTION
This bumps up the configure requirement for Module::Build and MakeMaker that supports test requires and MYMETA generation and merge, so that all the hacks inside Build.PL/Makefile.PL runtime can be eliminated. 

Fixes #168