### PR TITLE
Generate proper license in Build.PL

### DIFF
--- a/lib/Minilla/ModuleMaker/ModuleBuild.pm
+++ b/lib/Minilla/ModuleMaker/ModuleBuild.pm
@@ -88,7 +88,7 @@ check_bin('<?= $bin ?>');
 
 ? }
 my %args = (
-    license              => 'perl',
+    license              => '<?= $project->metadata->license->meta2_name ?>',
     dynamic_config       => 0,
 
     configure_requires => {


### PR DESCRIPTION
Otherwise it is always 'perl' while META.json
contains correct value. This may be confusing.