### PR TITLE
Always use 'git.config'

### DIFF
--- a/t/project/contributors.t
+++ b/t/project/contributors.t
@@ -12,6 +12,10 @@ use Minilla::Project;
 use Minilla::Git;
 
 subtest 'develop deps' => sub {
+    local %ENV;
+    delete $ENV{GIT_AUTHOR_NAME};
+    delete $ENV{GIT_AUTHOR_EMAIL};
+
     my $guard = pushd(tempdir());
 
     my $profile = Minilla::Profile::Default->new(

--- a/t/work_dir/release_test.t
+++ b/t/work_dir/release_test.t
@@ -11,6 +11,10 @@ use Minilla::Project;
 use Minilla::Git;
 
 subtest 'Contributors are included in stopwords' => sub {
+    local %ENV;
+    delete $ENV{GIT_AUTHOR_NAME};
+    delete $ENV{GIT_AUTHOR_EMAIL};
+
     my $guard = pushd(tempdir());
 
     my $profile = Minilla::Profile::Default->new(


### PR DESCRIPTION
Both 'git.config' and environment variables are set, then
environment variables are used, this causes test failure.

This is related to #187.