### PR TITLE
Delete system() function call

### DIFF
--- a/t/dist.t
+++ b/t/dist.t
@@ -26,7 +26,6 @@ for my $datfile (map { File::Spec->rel2abs($_) } 't/dist/Acme-FooXS.dat') {
         extract_archive($datfile);
         git_init_add_commit();
 
-        system 'cat lib/Acme/FooXS.pm';
         cmd_perl($minil, 'test');
 
         pass $distname;


### PR DESCRIPTION
Delete system() function call.
Some operating system don't have 'cat' cmd.

Only fix warning.

Before. (`windows 10` and `strawberry perl 5.22.1.3 / 64bit`)

```
$ prove -lc t\dist.t
t\dist.t .. 'cat' is not recognized as an internal or external command,
operable program or batch file.
t\dist.t .. ok
All tests successful.
Files=1, Tests=1,  4 wallclock secs ( 0.03 usr +  0.00 sys =  0.03 CPU)
Result: PASS
```

After.

```
$ prove -lc t\dist.t
t\dist.t .. ok
All tests successful.
Files=1, Tests=1,  5 wallclock secs ( 0.03 usr +  0.02 sys =  0.05 CPU)
Result: PASS
```