### PR TITLE
To suppress useless git diff, sort keys in Build.PL

### DIFF
--- a/lib/Minilla/ModuleMaker/ModuleBuild.pm
+++ b/lib/Minilla/ModuleMaker/ModuleBuild.pm
@@ -96,31 +96,31 @@ my %args = (
     },
 
     requires => {
-?       for my $requirement ( keys %{ $project->cpan_meta->prereqs->{runtime}{requires} } ){
+?       for my $requirement ( sort keys %{ $project->cpan_meta->prereqs->{runtime}{requires} } ){
         '<?= $requirement ?>' => '<?= $project->cpan_meta->prereqs->{runtime}{requires}{$requirement} ?>',
 ?       }
     },
 
     recommends => {
-?       for my $recommendation ( keys %{ $project->cpan_meta->prereqs->{runtime}{recommends} } ){
+?       for my $recommendation ( sort keys %{ $project->cpan_meta->prereqs->{runtime}{recommends} } ){
         '<?= $recommendation ?>' => '<?= $project->cpan_meta->prereqs->{runtime}{recommends}{$recommendation} ?>',
 ?       }
     },
 
     suggests => {
-?       for my $suggestion ( keys %{ $project->cpan_meta->prereqs->{runtime}{suggests} } ){
+?       for my $suggestion ( sort keys %{ $project->cpan_meta->prereqs->{runtime}{suggests} } ){
         '<?= $suggestion ?>' => '<?= $project->cpan_meta->prereqs->{runtime}{suggests}{$suggestion} ?>',
 ?       }
     },
 
     build_requires => {
-?       for my $requirement ( keys %{ $project->cpan_meta->prereqs->{build}{requires} } ){
+?       for my $requirement ( sort keys %{ $project->cpan_meta->prereqs->{build}{requires} } ){
         '<?= $requirement ?>' => '<?= $project->cpan_meta->prereqs->{build}{requires}{$requirement} ?>',
 ?       }
     },
 
     test_requires => {
-?       for my $requirement ( keys %{ $project->cpan_meta->prereqs->{test}{requires} } ){
+?       for my $requirement ( sort keys %{ $project->cpan_meta->prereqs->{test}{requires} } ){
         '<?= $requirement ?>' => '<?= $project->cpan_meta->prereqs->{test}{requires}{$requirement} ?>',
 ?       }
     },


### PR DESCRIPTION
As is well-known, keys() function of Perl 5.18+ returns keys randomly.
So `minil build` may generate different Build.PL each time. 

This PR suppresses this by sorting keys.

I found this while building https://github.com/gfx/Perl-Data-Util.