### PR TITLE
Additional badges parameters for Travis CI

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -38,6 +38,7 @@ requires 'Moo' => 1.001000;
 requires 'Data::Section::Simple' => 0.04;
 requires 'Term::ANSIColor';
 requires 'Module::Runtime';
+requires 'URI';
 
 # Modules required by minil new/minil dist/minil release are optional.
 # It's good for contributors

--- a/lib/Minilla.pm
+++ b/lib/Minilla.pm
@@ -201,8 +201,8 @@ See L<CPAN::Meta::Spec>.
 
 Embed badges image (e.g. Travis-CI) to README.md. It ought to be array and each elements must be service name. Now, supported services are only 'travis', 'circleci', 'appveyor', 'coveralls', 'codecov' and 'gitter'.
 
-If your project is in a private repo, the badge needs a access token to show up which you can include in the service name
-like this: C<travis?[YOUR_TOKEN_GOES_HERE]>. Note: Only Travis CI is supported right now.
+You can send additional parameters as required by your CI provider by including a
+query string along with your service name: eg. C<travis?token=[YOUR_TOKEN_GOES_HERE]&branch=dev>
 
 =item PL_files
 

--- a/lib/Minilla.pm
+++ b/lib/Minilla.pm
@@ -201,6 +201,9 @@ See L<CPAN::Meta::Spec>.
 
 Embed badges image (e.g. Travis-CI) to README.md. It ought to be array and each elements must be service name. Now, supported services are only 'travis', 'circleci', 'appveyor', 'coveralls', 'codecov' and 'gitter'.
 
+If your project is in a private repo, the badge needs a access token to show up which you can include in the service name
+like this: C<travis?[YOUR_TOKEN_GOES_HERE]>. Note: Only Travis CI is supported right now.
+
 =item PL_files
 
 Specify the PL files.

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -624,8 +624,14 @@ sub regenerate_readme_md {
         my @badges;
         if ($user_name && $repository_name) {
             for my $badge (@{$self->badges}) {
-                if ($badge eq 'travis') {
-                    push @badges, "[![Build Status](https://travis-ci.org/$user_name/$repository_name.svg?branch=master)](https://travis-ci.org/$user_name/$repository_name)";
+                if ($badge =~ /^travis(?:\?(.*?))?$/) {
+                    my $token = $1;
+                    if (!defined($token)) {
+                      push @badges, "[![Build Status](https://travis-ci.org/$user_name/$repository_name.svg?branch=master)](https://travis-ci.org/$user_name/$repository_name)";
+                    }
+                    else {
+                      push @badges, "[![Build Status](https://travis-ci.com/$user_name/$repository_name.svg?token=$token&branch=master)](https://travis-ci.com/$user_name/$repository_name)";
+                    }
                 } elsif ($badge eq 'appveyor') {
                     push @badges, "[![Build Status](https://img.shields.io/appveyor/ci/$user_name/$repository_name/master.svg)](https://ci.appveyor.com/project/$user_name/$repository_name/branch/master)";
                 } elsif ($badge eq 'coveralls') {

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -23,6 +23,7 @@ use Minilla::ModuleMaker::ModuleBuildTiny;
 use Minilla::ModuleMaker::ExtUtilsMakeMaker;
 use Minilla::Util qw(slurp_utf8 find_dir cmd spew_raw slurp_raw);
 use Encode qw(decode_utf8);
+use URI;
 
 use Moo;
 
@@ -624,23 +625,36 @@ sub regenerate_readme_md {
         my @badges;
         if ($user_name && $repository_name) {
             for my $badge (@{$self->badges}) {
-                if ($badge =~ /^travis(?:\?(.*?))?$/) {
-                    my $token = $1;
-                    if (!defined($token)) {
-                      push @badges, "[![Build Status](https://travis-ci.org/$user_name/$repository_name.svg?branch=master)](https://travis-ci.org/$user_name/$repository_name)";
+                my $uri = URI->new( $badge );
+                my $service_name = $uri->path;
+                if ($service_name eq 'travis') {
+                    my $build_uri = $uri->clone;
+                    $build_uri->scheme('https');
+                    $build_uri->path("$user_name/$repository_name");
+                    $build_uri->query_form({});
+                    my $image_uri = $uri->clone;
+                    $image_uri->scheme('https');
+                    $image_uri->path("$user_name/$repository_name.svg");
+                    my %image_uri_qs = $image_uri->query_form;
+                    $image_uri_qs{branch} = 'master' if !defined($image_uri_qs{branch});
+                    if (!defined($image_uri_qs{token})) {
+                        $_->host("travis-ci.org") foreach ($build_uri, $image_uri);
+                    } else {
+                        $_->host("travis-ci.com") foreach ($build_uri, $image_uri);
                     }
-                    else {
-                      push @badges, "[![Build Status](https://travis-ci.com/$user_name/$repository_name.svg?token=$token&branch=master)](https://travis-ci.com/$user_name/$repository_name)";
-                    }
-                } elsif ($badge eq 'appveyor') {
+                    # Sort the query params so that the end URL is
+                    # deterministic and easier to test.
+                    $image_uri->query_form( map { ( $_, $image_uri_qs{$_} ) } sort keys %image_uri_qs );
+                    push @badges, "[![Build Status]($image_uri)]($build_uri)";
+                } elsif ($service_name eq 'appveyor') {
                     push @badges, "[![Build Status](https://img.shields.io/appveyor/ci/$user_name/$repository_name/master.svg)](https://ci.appveyor.com/project/$user_name/$repository_name/branch/master)";
-                } elsif ($badge eq 'coveralls') {
+                } elsif ($service_name eq 'coveralls') {
                     push @badges, "[![Coverage Status](https://img.shields.io/coveralls/$user_name/$repository_name/master.svg?style=flat)](https://coveralls.io/r/$user_name/$repository_name?branch=master)"
-                } elsif ($badge eq 'codecov') {
+                } elsif ($service_name eq 'codecov') {
                     push @badges, "[![Coverage Status](http://codecov.io/github/$user_name/$repository_name/coverage.svg?branch=master)](https://codecov.io/github/$user_name/$repository_name?branch=master)";
-                } elsif ($badge eq 'gitter') {
+                } elsif ($service_name eq 'gitter') {
                     push @badges, "[![Gitter chat](https://badges.gitter.im/$user_name/$repository_name.png)](https://gitter.im/$user_name/$repository_name)";
-                } elsif ($badge eq 'circleci') {
+                } elsif ($service_name eq 'circleci') {
                     push @badges, "[![Build Status](https://circleci.com/gh/$user_name/$repository_name.svg)](https://circleci.com/gh/$user_name/$repository_name)";
                 }
             }

--- a/t/project/badge.t
+++ b/t/project/badge.t
@@ -77,6 +77,24 @@ subtest 'Badge' => sub {
         ok chomp (my $got = <$fh>);
         is $got, "# NAME";
     };
+
+    # NOTE: When we add support for other providers, we can extend this test.
+    subtest 'Private repo support' => sub {
+        write_minil_toml({
+            name   => 'Acme-Foo',
+            badges => ['travis?xxxyyyzzz'],
+        });
+        $project->regenerate_files;
+
+        open my $fh, '<', 'README.md';
+        ok chomp (my $got = <$fh>);
+
+        my $badge_markdowns = [
+            "[![Build Status](https://travis-ci.com/tokuhirom/Minilla.svg?token=xxxyyyzzz&branch=master)](https://travis-ci.com/tokuhirom/Minilla)",
+        ];
+        my $expected = join(' ', @$badge_markdowns);
+        is $got, $expected;
+    };
 };
 
 done_testing;

--- a/t/project/badge.t
+++ b/t/project/badge.t
@@ -79,10 +79,10 @@ subtest 'Badge' => sub {
     };
 
     # NOTE: When we add support for other providers, we can extend this test.
-    subtest 'Private repo support' => sub {
+    subtest 'Badge additional parameters' => sub {
         write_minil_toml({
             name   => 'Acme-Foo',
-            badges => ['travis?xxxyyyzzz'],
+            badges => ['travis?foo=bar&token=xxxyyyzzz'],
         });
         $project->regenerate_files;
 
@@ -90,7 +90,7 @@ subtest 'Badge' => sub {
         ok chomp (my $got = <$fh>);
 
         my $badge_markdowns = [
-            "[![Build Status](https://travis-ci.com/tokuhirom/Minilla.svg?token=xxxyyyzzz&branch=master)](https://travis-ci.com/tokuhirom/Minilla)",
+            "[![Build Status](https://travis-ci.com/tokuhirom/Minilla.svg?branch=master&foo=bar&token=xxxyyyzzz)](https://travis-ci.com/tokuhirom/Minilla)",
         ];
         my $expected = join(' ', @$badge_markdowns);
         is $got, $expected;


### PR DESCRIPTION
To enable this feature, while specifying a CI provider in `badges`, the user can include additional parameters as a query string:

```
badges: [ "travis?token=xxxxyyyyzzzz&branch=dev" ]
```

We can add this support for other CI providers supported by Minilla as well.
