### PR TITLE
Add support for MetaCPAN badge

### DIFF
--- a/lib/Minilla.pm
+++ b/lib/Minilla.pm
@@ -197,9 +197,9 @@ See L<CPAN::Meta::Spec>.
 
 =item badges
 
-    badges = ['travis', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter']
+    badges = ['travis', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter', 'metacpan']
 
-Embed badges image (e.g. Travis-CI) to README.md. It ought to be array and each elements must be service name. Now, supported services are only 'travis', 'circleci', 'appveyor', 'coveralls', 'codecov' and 'gitter'.
+Embed badges image (e.g. Travis-CI) to README.md. It ought to be array and each elements must be service name. Now, supported services are only 'travis', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter' and 'metacpan'.
 
 =item PL_files
 

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -636,6 +636,8 @@ sub regenerate_readme_md {
                     push @badges, "[![Gitter chat](https://badges.gitter.im/$user_name/$repository_name.png)](https://gitter.im/$user_name/$repository_name)";
                 } elsif ($badge eq 'circleci') {
                     push @badges, "[![Build Status](https://circleci.com/gh/$user_name/$repository_name.svg)](https://circleci.com/gh/$user_name/$repository_name)";
+                } elsif ($badge eq 'metacpan') {
+                    push @badges, "[![MetaCPAN Release](https://badge.fury.io/pl/$repository_name.svg)](https://metacpan.org/release/$repository_name)";
                 }
             }
         }

--- a/t/project/badge.t
+++ b/t/project/badge.t
@@ -38,7 +38,7 @@ subtest 'Badge' => sub {
     subtest 'Badges exist' => sub {
         write_minil_toml({
             name   => 'Acme-Foo',
-            badges => ['travis', 'circleci', 'appveyor', 'coveralls', 'gitter', 'codecov'],
+            badges => ['travis', 'circleci', 'appveyor', 'coveralls', 'gitter', 'codecov', 'metacpan'],
         });
         $project->regenerate_files;
 
@@ -52,6 +52,7 @@ subtest 'Badge' => sub {
             "[![Coverage Status](https://img.shields.io/coveralls/tokuhirom/Minilla/master.svg?style=flat)](https://coveralls.io/r/tokuhirom/Minilla?branch=master)",
             "[![Gitter chat](https://badges.gitter.im/tokuhirom/Minilla.png)](https://gitter.im/tokuhirom/Minilla)",
             "[![Coverage Status](http://codecov.io/github/tokuhirom/Minilla/coverage.svg?branch=master)](https://codecov.io/github/tokuhirom/Minilla?branch=master)",
+            "[![MetaCPAN Release](https://badge.fury.io/pl/Minilla.svg)](https://metacpan.org/release/Minilla)"
         ];
         my $expected = join(' ', @$badge_markdowns);
         is $got, $expected;


### PR DESCRIPTION
This lets the generated README.md have a MetaCPAN badge (generated via https://badge.fury.io/for/pl)

See also https://github.com/metacpan/metacpan-api/issues/261