### PR TITLE
Use module name instead of repository name for metacpan badge

### DIFF
--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -657,7 +657,8 @@ sub regenerate_readme_md {
                 } elsif ($service_name eq 'circleci') {
                     push @badges, "[![Build Status](https://circleci.com/gh/$user_name/$repository_name.svg)](https://circleci.com/gh/$user_name/$repository_name)";
                 } elsif ($service_name eq 'metacpan') {
-                    push @badges, "[![MetaCPAN Release](https://badge.fury.io/pl/$repository_name.svg)](https://metacpan.org/release/$repository_name)";
+                    my $module_name = $self->config->{name} || $repository_name;
+                    push @badges, "[![MetaCPAN Release](https://badge.fury.io/pl/$module_name.svg)](https://metacpan.org/release/$module_name)";
                 }
             }
         }

--- a/t/project/badge.t
+++ b/t/project/badge.t
@@ -52,7 +52,7 @@ subtest 'Badge' => sub {
             "[![Coverage Status](https://img.shields.io/coveralls/tokuhirom/Minilla/master.svg?style=flat)](https://coveralls.io/r/tokuhirom/Minilla?branch=master)",
             "[![Gitter chat](https://badges.gitter.im/tokuhirom/Minilla.png)](https://gitter.im/tokuhirom/Minilla)",
             "[![Coverage Status](http://codecov.io/github/tokuhirom/Minilla/coverage.svg?branch=master)](https://codecov.io/github/tokuhirom/Minilla?branch=master)",
-            "[![MetaCPAN Release](https://badge.fury.io/pl/Minilla.svg)](https://metacpan.org/release/Minilla)"
+            "[![MetaCPAN Release](https://badge.fury.io/pl/Acme-Foo.svg)](https://metacpan.org/release/Acme-Foo)"
         ];
         my $expected = join(' ', @$badge_markdowns);
         is $got, $expected;


### PR DESCRIPTION
Some perl repositories are named like p5-Foo-Bar, but its module
name is Foo::Bar(Foo-Bar). Badge URL of such modules are invalid.

CC: @zakame