### PR TITLE
Remove @INC optimization. It doesn't work on ubuntu( #205 ).

### DIFF
--- a/lib/Minilla/Util.pm
+++ b/lib/Minilla/Util.pm
@@ -139,20 +139,10 @@ sub require_optional {
 sub cmd_perl {
     my(@args) = @_;
 
-    require Config;
+    my @abs_inc = map { $_ eq '.' ? $_ : File::Spec->rel2abs($_) }
+                      @INC;
 
-    my %std_inc = map { $_ => 1 } @Config::Config{qw(
-        sitelibexp sitearchexp
-        privlibexp archlibexp
-        otherlibdirs
-    )};
-    if ($Config::Config{usevendorprefix}) {
-        @std_inc{'vendorarchexp', 'vendorlibexp'} = (1, 1);
-    }
-    my @non_std_inc = map { $_ eq '.' ? $_ : File::Spec->rel2abs($_) }
-                      grep { not $std_inc{$_} } @INC;
-
-    cmd($^X, (map { "-I$_" } @non_std_inc), @args);
+    cmd($^X, (map { "-I$_" } @abs_inc), @args);
 }
 
 sub cmd {


### PR DESCRIPTION
`cmd_perl` passes library paths from @INC excludes it listed in sitelibexp, sitearchexp, privlibexp  and archlibexp. But it causes an issue on ubuntu. It shares library directories with some Perl versions.

gfx, the original implementor of `cmd_perl`, says there's no reason to filter sitelibexp, sitearchexp, privlibexp  and archlibexp. As a result, we should remove this filter.

Here's a chat log(You can read following logs with Google Translator)

    gfx @tokuhirom そのロジック、どこかから拝借してきた気がするんだよね…。

    [9:15 AM]
    tokuhirom そんな感じのコードではあるが、出所不明すぎるw

    [9:16 AM]
    gfx うーむ。全然覚えてない。

    [9:20 AM]
    charsbar https://metacpan.org/source/GFUJI/lib-xi-1.03/lib/lib/xi.pm#L25-38

    [9:20 AM]
    これがさらにどこから来たのかはわからんけど。

    [9:22 AM]
    tokuhirom やる意味はないと思うんだよね

    [9:22 AM]
    なんか謎のこだわりっぽさある

    [9:23 AM]
    gfx おー

    [9:23 AM]
    いや、それ見たら思い出した！やっぱり、単にもともと `@INC` に入ってるパスはいれる意味ないよね、ということで取ってるだけだと思います！

    [9:26 AM]
    kazuho 違うパスにある perl を呼び出す場合は意味のあるコードですねw

    [9:26 AM]
    tokuhirom じゃあ、素直に除くか

    [9:27 AM]
    gfx +1