### PR TITLE
allow 'Metadata' section in minil.toml

### DIFF
--- a/lib/Minilla.pm
+++ b/lib/Minilla.pm
@@ -388,6 +388,14 @@ or program. Build fail if the command does not exist.
 Use a different module to generate C<README.md> from your pod. This
 module must subclass L<Pod::Markdown>.
 
+=item Metadata
+
+    [Metadata]
+    x_static_install = 1
+    x_deprecated = 1
+
+Add arbitrary keys to C<META.json>/C<META.yml>.
+
 =back
 
 =head1 FAQ

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -449,6 +449,9 @@ sub cpan_meta {
     if (my $authority = $self->config->{authority}) {
         $dat->{x_authority} = $authority;
     }
+    if (my $metadata = $self->config->{Metadata}) {
+        $dat->{$_} = $metadata->{$_} for keys %$metadata;
+    }
 
     # fill 'provides' section
     if ($release_status ne 'unstable') {

--- a/t/project/meta.t
+++ b/t/project/meta.t
@@ -176,6 +176,36 @@ subtest 'resources' => sub {
     };
 };
 
+subtest 'Metadata' => sub {
+    my $guard = pushd(tempdir());
+
+    my $profile = Minilla::Profile::Default->new(
+        author => 'foo',
+        dist => 'Acme-Foo',
+        path => 'Acme/Foo.pm',
+        suffix => 'Foo',
+        module => 'Acme::Foo',
+        version => '0.01',
+        email => 'foo@example.com',
+    );
+    $profile->generate();
+    write_minil_toml({
+        name => 'Acme-Foo',
+        Metadata => {
+            x_deprecated => 1,
+            x_static_install => 1,
+        },
+    });
+
+    git_init_add_commit();
+
+    Minilla::Project->new()->regenerate_files;
+
+    my $meta = CPAN::Meta->load_file('META.json');
+    ok $meta->{x_static_install};
+    ok $meta->{x_deprecated};
+};
+
 
 done_testing;
 


### PR DESCRIPTION
This PR allows 'Metadata' section in minil.toml, so that we can adds keys to META.json/META.yml.

Especially, I want to set x_static_install true in minillalized distribution.