### PR TITLE
fix shebang so that toolchains rewrite it

### DIFF
--- a/script/minil
+++ b/script/minil
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!perl
 use strict;
 use warnings;
 use Minilla::CLI;


### PR DESCRIPTION
If we use `#!perl`, then toolchains will rewrite it in installation time.

If you intentionally use the env shenbang, please ignore this PR. Thanks.