### PR TITLE
fix how to extract perl version from v-string

### DIFF
--- a/lib/Minilla/Metadata.pm
+++ b/lib/Minilla/Metadata.pm
@@ -73,8 +73,7 @@ sub _extract_perl_version {
         $_[0] =~ m/
         ^\s*
         (?:use|require) \s*
-        v?
-        ([\d_\.]+)
+        (v?[\d_\.]+)
         \s* ;
         /ixms
     ) {


### PR DESCRIPTION
fix #198 

As in #198, if a pm file contains `use v5.20;`, then minilla produces META.json containing
```
   "prereqs" : {
      ...
      "runtime" : {
         "requires" : {
            "perl" : "5.20"
         }
      },
```
which means this distribution requires perl 5.200_000.

This PR fixes this issue by extracting perl version together with leading "v".