### PR TITLE
Unset GIT_CONFIG environment variable

### DIFF
--- a/t/Util.pm
+++ b/t/Util.pm
@@ -23,6 +23,7 @@ plan skip_all => "No git command" unless which('git');
 plan skip_all => "No cpanm command" unless which('cpanm');
 plan skip_all => "No git configuration" unless `git config user.email` =~ /\@/;
 $ENV{PERL_CPANM_HOME} = tempdir();
+delete $ENV{GIT_CONFIG};
 
 our @EXPORT = (
     qw(git_init_add_commit write_minil_toml),


### PR DESCRIPTION
Because if GIT_CONFIG is set, 'git config' command uses its file instead
of .git/config. So some tests which check .git/config content are failed
in such case.

This fixes #211 