### PR TITLE
Push '.' to @INC when custom builder is used

### DIFF
--- a/lib/Minilla/ModuleMaker/ModuleBuild.pm
+++ b/lib/Minilla/ModuleMaker/ModuleBuild.pm
@@ -75,7 +75,7 @@ use strict;
 use warnings;
 use utf8;
 
-? if ( $project->build_class ne 'Module::Build' ) {
+? if ( $project->build_class !~ m/^Module::Build(?:::XSUtil)?$/ ) {
 BEGIN { push @INC, '.' }
 ? }
 use <?= $project->build_class ?>;

--- a/lib/Minilla/ModuleMaker/ModuleBuild.pm
+++ b/lib/Minilla/ModuleMaker/ModuleBuild.pm
@@ -75,6 +75,9 @@ use strict;
 use warnings;
 use utf8;
 
+? if ( $project->build_class ne 'Module::Build' ) {
+BEGIN { push @INC, '.' }
+? }
 use <?= $project->build_class ?>;
 use File::Basename;
 use File::Spec;


### PR DESCRIPTION
`@INC` does not contain current directory from Perl 5.25.9.
This is related to #215.