### PR TITLE
Use FindBin::Bin instead of '.'

### DIFF
--- a/lib/Minilla/ModuleMaker/ModuleBuild.pm
+++ b/lib/Minilla/ModuleMaker/ModuleBuild.pm
@@ -76,7 +76,8 @@ use warnings;
 use utf8;
 
 ? if ( $project->build_class !~ m/^Module::Build(?:::XSUtil)?$/ ) {
-BEGIN { push @INC, '.' }
+use FindBin;
+use lib $FindBin::Bin;
 ? }
 use <?= $project->build_class ?>;
 use File::Basename;


### PR DESCRIPTION
Because 'cpan' client fails to install when '.' is used. I confirmed install Mouse by `cpan` with this change.

See also
- https://github.com/gfx/p5-Mouse/issues/74