### PR TITLE
sort x_contributors section to avoid unnecessary diff

### DIFF
--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -703,7 +703,7 @@ sub _build_contributors {
     @lines = grep { !$is_author{$normalize->($_)} } @lines;
     @lines = grep { $_ ne 'Your Name <you@example.com>' } @lines;
     @lines = grep { ! /^\(no author\) <\(no author\)\@[\d\w\-]+>$/ } @lines;
-    \@lines;
+    [sort @lines];
 }
 
 sub _build_work_dir {

--- a/t/project/contributors.t
+++ b/t/project/contributors.t
@@ -55,14 +55,14 @@ subtest 'develop deps' => sub {
     my $project = Minilla::Project->new();
     is_deeply(
         $project->contributors,
-        ['Foo <foo@example.com>',
-        'Bar <bar@example.com>'],
+        ['Bar <bar@example.com>',
+        'Foo <foo@example.com>'],
     );
     $project->regenerate_files();
     is_deeply(
         CPAN::Meta->load_file('META.json')->{x_contributors},
-        ['Foo <foo@example.com>',
-        'Bar <bar@example.com>'],
+        ['Bar <bar@example.com>',
+        'Foo <foo@example.com>'],
     );
 };
 


### PR DESCRIPTION
Currently the order of x_contributors is the same as `git log --format="%aN"`.
Then it happens that `minil build` emits a different META.json even though the contributors are same.

This PR prevents this by sorting x_contributors section.