### PR TITLE
Handle AppVeyor renaming repository

### DIFF
--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -650,8 +650,8 @@ sub regenerate_readme_md {
                     $image_uri->query_form( map { ( $_, $image_uri_qs{$_} ) } sort keys %image_uri_qs );
                     push @badges, "[![Build Status]($image_uri)]($build_uri)";
                 } elsif ($service_name eq 'appveyor') {
-                    $repository_name =~ s/\./-/g;
-                    push @badges, "[![Build Status](https://img.shields.io/appveyor/ci/$user_name/$repository_name/master.svg)](https://ci.appveyor.com/project/$user_name/$repository_name/branch/master)";
+                    ( my $appveyor_repository_name = $repository_name ) =~ s/\./-/g;
+                    push @badges, "[![Build Status](https://img.shields.io/appveyor/ci/$user_name/$appveyor_repository_name/master.svg)](https://ci.appveyor.com/project/$user_name/$appveyor_repository_name/branch/master)";
                 } elsif ($service_name eq 'coveralls') {
                     push @badges, "[![Coverage Status](https://img.shields.io/coveralls/$user_name/$repository_name/master.svg?style=flat)](https://coveralls.io/r/$user_name/$repository_name?branch=master)"
                 } elsif ($service_name eq 'codecov') {

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -650,6 +650,7 @@ sub regenerate_readme_md {
                     $image_uri->query_form( map { ( $_, $image_uri_qs{$_} ) } sort keys %image_uri_qs );
                     push @badges, "[![Build Status]($image_uri)]($build_uri)";
                 } elsif ($service_name eq 'appveyor') {
+                    $repository_name =~ s/\./-/;
                     push @badges, "[![Build Status](https://img.shields.io/appveyor/ci/$user_name/$repository_name/master.svg)](https://ci.appveyor.com/project/$user_name/$repository_name/branch/master)";
                 } elsif ($service_name eq 'coveralls') {
                     push @badges, "[![Coverage Status](https://img.shields.io/coveralls/$user_name/$repository_name/master.svg?style=flat)](https://coveralls.io/r/$user_name/$repository_name?branch=master)"

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -650,7 +650,7 @@ sub regenerate_readme_md {
                     $image_uri->query_form( map { ( $_, $image_uri_qs{$_} ) } sort keys %image_uri_qs );
                     push @badges, "[![Build Status]($image_uri)]($build_uri)";
                 } elsif ($service_name eq 'appveyor') {
-                    $repository_name =~ s/\./-/;
+                    $repository_name =~ s/\./-/g;
                     push @badges, "[![Build Status](https://img.shields.io/appveyor/ci/$user_name/$repository_name/master.svg)](https://ci.appveyor.com/project/$user_name/$repository_name/branch/master)";
                 } elsif ($service_name eq 'coveralls') {
                     push @badges, "[![Coverage Status](https://img.shields.io/coveralls/$user_name/$repository_name/master.svg?style=flat)](https://coveralls.io/r/$user_name/$repository_name?branch=master)"

--- a/t/project/badge.t
+++ b/t/project/badge.t
@@ -97,6 +97,37 @@ subtest 'Badge' => sub {
         my $expected = join(' ', @$badge_markdowns);
         is $got, $expected;
     };
+
+    subtest 'AppVeyor repository rename' => sub {
+        my $guard   = pushd( tempdir() );
+        my $profile = Minilla::Profile::Default->new(
+            dist    => 'Hashids',
+            path    => 'Hashids.pm',
+            module  => 'Hashids',
+        );
+        $profile->generate();
+        git_init_add_commit();
+        my $project = Minilla::Project->new();
+        {
+            open my $fh, '>>', catdir('.git', 'config');
+            print $fh <<'...';
+[remote "origin"]
+    fetch = +refs/heads/*:refs/remotes/origin/*
+    url = git@github.com:zakame/hashids.pm.git
+...
+        }
+
+        write_minil_toml({
+            name => 'Hashids',
+            badges => ['appveyor'],
+        });
+        $project->regenerate_files;
+
+        open my $fh, '<', 'README.md';
+        ok chomp (my $got = <$fh>);
+
+        is $got, "[![Build Status](https://img.shields.io/appveyor/ci/zakame/hashids-pm/master.svg)](https://ci.appveyor.com/project/zakame/hashids-pm/branch/master)";
+    };
 };
 
 done_testing;

--- a/t/project/badge.t
+++ b/t/project/badge.t
@@ -117,16 +117,35 @@ subtest 'Badge' => sub {
 ...
         }
 
-        write_minil_toml({
-            name => 'Hashids',
-            badges => ['appveyor'],
-        });
-        $project->regenerate_files;
+        {
+            write_minil_toml(
+                {   name   => 'Hashids',
+                    badges => ['appveyor'],
+                }
+            );
+            $project->regenerate_files;
 
-        open my $fh, '<', 'README.md';
-        ok chomp (my $got = <$fh>);
+            open my $fh, '<', 'README.md';
+            ok chomp( my $got = <$fh> );
 
-        is $got, "[![Build Status](https://img.shields.io/appveyor/ci/zakame/hashids-pm/master.svg)](https://ci.appveyor.com/project/zakame/hashids-pm/branch/master)";
+            is $got,
+                "[![Build Status](https://img.shields.io/appveyor/ci/zakame/hashids-pm/master.svg)](https://ci.appveyor.com/project/zakame/hashids-pm/branch/master)";
+        }
+
+        subtest 'AppVeyor in badge list' => sub {
+            write_minil_toml(
+                {   name   => 'Hashids',
+                    badges => [ 'appveyor', 'travis' ],
+                }
+            );
+            $project->regenerate_files;
+
+            open my $fh, '<', 'README.md';
+            ok chomp( my $got = <$fh> );
+
+            my $expected = "[![Build Status](https://img.shields.io/appveyor/ci/zakame/hashids-pm/master.svg)](https://ci.appveyor.com/project/zakame/hashids-pm/branch/master) [![Build Status](https://travis-ci.org/zakame/hashids.pm.svg?branch=master)](https://travis-ci.org/zakame/hashids.pm)";
+            is $got, $expected;
+        };
     };
 };
 


### PR DESCRIPTION
I just found out that AppVeyor does a `$repository_name ~= s/\./-/g` so
take account for that when regenerating the badge.