### PR TITLE
fix `minil build` command generated "release_status" in META.json

### DIFF
--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -564,7 +564,7 @@ sub regenerate_files {
 sub regenerate_meta_json {
     my $self = shift;
 
-    my $meta = $self->cpan_meta('unstable');
+    my $meta = $self->cpan_meta();
     $meta->save(File::Spec->catfile($self->dir, 'META.json'), {
         version => '2.0'
     });

--- a/t/project/stable.t
+++ b/t/project/stable.t
@@ -15,7 +15,7 @@ use File::Spec;
 
 use Minilla::CLI::Build;
 
-subtest 'unstable' => sub {
+subtest 'stable' => sub {
     my $guard = pushd(tempdir());
 
     my $profile = Minilla::Profile::Default->new(
@@ -24,7 +24,7 @@ subtest 'unstable' => sub {
         path => 'Acme/Foo.pm',
         suffix => 'Foo',
         module => 'Acme::Foo',
-        version => '0.01_01',
+        version => '3.008008',
         email => 'tokuhirom@example.com',
     );
     $profile->generate();
@@ -39,10 +39,10 @@ subtest 'unstable' => sub {
     my $metapath = File::Spec->catfile($work_dir->dir, 'META.json');
     ok -f $metapath;
     my $meta = CPAN::Meta->load_file($metapath);
-    is($meta->{release_status}, 'unstable');
+    is($meta->{release_status}, 'stable');
 };
 
-subtest 'unstable_with_cli' => sub {
+subtest 'stable_with_cli' => sub {
     my $guard = pushd(tempdir());
 
     my $profile = Minilla::Profile::Default->new(
@@ -51,7 +51,7 @@ subtest 'unstable_with_cli' => sub {
         path => 'Acme/Foo.pm',
         suffix => 'Foo',
         module => 'Acme::Foo',
-        version => '0.01_01',
+        version => '3.008008',
         email => 'tokuhirom@example.com',
     );
     $profile->generate();
@@ -66,7 +66,7 @@ subtest 'unstable_with_cli' => sub {
     my $metapath = File::Spec->catfile($guard, 'META.json');
     ok -f $metapath;
     my $meta = CPAN::Meta->load_file($metapath);
-    is($meta->{release_status}, 'unstable');
+    is($meta->{release_status}, 'stable');
 };
 
 done_testing;


### PR DESCRIPTION
Hello.

`minil build` command (in command line) generated wrong "release_status" in META.json - look on [https://github.com/tokuhirom/Minilla/blob/master/META.json](https://github.com/tokuhirom/Minilla/blob/master/META.json) is `unstable` but Minilla version is "v3.0.13".

Also I add test for stable version (stable.t) and test for Minilla::CLI::Build;

Best Regards, Ilya Pavlov