### PR TITLE
Adjust dependency around release testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ But, you can write configurations to _minil.toml_ file in [TOML](https://github.
     Embed badges image (e.g. Travis-CI) to README.md. It ought to be array and each elements must be service name. Now, supported services are only 'travis', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter' and 'metacpan'.
 
     You can send additional parameters as required by your CI provider by including a
-    query string along with your service name: eg. `travis?token=[YOUR_TOKEN_GOES_HERE]&branch=dev`
+    query string along with your service name: e.g. `travis?token=[YOUR_TOKEN_GOES_HERE]&branch=dev`
 
 - PL\_files
 

--- a/cpanfile
+++ b/cpanfile
@@ -25,7 +25,6 @@ requires 'Config::Identity';
 
 # File operation
 requires 'File::pushd';
-requires 'File::Copy::Recursive';
 requires 'File::Which';
 
 # OOPS
@@ -61,6 +60,7 @@ on 'test' => sub {
     requires 'Test::More' => '0.98';
     requires 'Test::Requires' => 0;
     requires 'Test::Output';
+    requires 'File::Copy::Recursive';
     requires 'File::Temp';
     recommends 'Devel::CheckLib';
     suggests 'Dist::Zilla';

--- a/cpanfile
+++ b/cpanfile
@@ -53,7 +53,7 @@ recommends 'Software::License', '0.103010';
 # release testing
 recommends 'Test::Pod';
 recommends 'Test::Spellunker', 'v0.2.7';
-recommends 'Test::MinimumVersion' => '0.101080';
+recommends 'Test::MinimumVersion::Fast' => '0.04';
 recommends 'Test::CPAN::Meta';
 recommends 'Test::PAUSE::Permissions';
 

--- a/lib/Minilla.pm
+++ b/lib/Minilla.pm
@@ -260,7 +260,7 @@ See L<CPAN::Meta::Spec>.
 Embed badges image (e.g. Travis-CI) to README.md. It ought to be array and each elements must be service name. Now, supported services are only 'travis', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter' and 'metacpan'.
 
 You can send additional parameters as required by your CI provider by including a
-query string along with your service name: eg. C<travis?token=[YOUR_TOKEN_GOES_HERE]&branch=dev>
+query string along with your service name: e.g. C<travis?token=[YOUR_TOKEN_GOES_HERE]&branch=dev>
 
 =item PL_files
 

--- a/t/dist.t
+++ b/t/dist.t
@@ -9,7 +9,6 @@ use File::Spec;
 use File::Spec::Functions qw(catdir);
 use File::Path;
 use File::Basename;
-use File::Copy::Recursive qw(rcopy);
 
 use Minilla::Git;
 


### PR DESCRIPTION
- Drop Test::MinimumVersion
- Add Test::MinimumVersion::Fast

Test::MinimumVersion is no longer used and Test::MinimumVersion::Fast is used
on release testing.