### PR TITLE
suppress `Wide character` warnings while regenerating README.md

### DIFF
--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -21,7 +21,7 @@ use Minilla::ReleaseTest;
 use Minilla::ModuleMaker::ModuleBuild;
 use Minilla::ModuleMaker::ModuleBuildTiny;
 use Minilla::ModuleMaker::ExtUtilsMakeMaker;
-use Minilla::Util qw(slurp_utf8 find_dir cmd spew_raw slurp_raw);
+use Minilla::Util qw(slurp_utf8 find_dir cmd spew_raw slurp_raw spew_utf8);
 use Encode qw(decode_utf8);
 use URI;
 
@@ -262,7 +262,7 @@ sub _build_dist_name {
         my $conf = $self->config;
         if ($conf->{name} =~ /::/) {
             (my $better_name = $conf->{name}) =~ s/::/-/g;
-            Carp::croak(qq!You shouldn't set 'name="$conf->{name}"' in minil.toml. You need to set the value as 'name="$better_name"'.!);
+            Carp::croak(qq(You shouldn't set 'name="$conf->{name}"' in minil.toml. You need to set the value as 'name="$better_name"'.));
         }
         $dist_name = $conf->{name};
     }
@@ -583,7 +583,7 @@ sub generate_minil_toml {
     my %pause;
     if (eval { %pause = Config::Identity::PAUSE->load; 1; } && exists $pause{user}) {
         my $user = uc($pause{user});
-        $content .= qq{\nauthority="cpan:${user}"\n},
+        $content .= qq(\nauthority="cpan:${user}"\n);
     }
     warn $@ if $@;
 
@@ -671,7 +671,7 @@ sub regenerate_readme_md {
         $markdown = join(' ', @badges) . $markdown
     }
 
-    spew_raw($fname, $markdown);
+    spew_utf8($fname, $markdown);
 }
 
 sub verify_prereqs {


### PR DESCRIPTION
The `Pod::Markdown->parse->as_markdown` returns Perl string, so
use the spew_utf8 function to avoid `Wide character in print`
warnings when multibyte is described in `pod`.