### PR TITLE
add os_unsupported support

### DIFF
--- a/lib/Minilla.pm
+++ b/lib/Minilla.pm
@@ -367,6 +367,16 @@ This variable disables CPAN upload feature.
 
 Commands that are specified by this option will be executed when releasing. If result of commands is not successful, it will abort.
 
+=item unsupported.os
+
+    [unsupported]
+    os = [
+        "MSWin32",
+        "darwin"
+    ]
+
+By setting this value to add unsupported OS checks for (Build.PL|Makefile.PL).
+
 =item ReleaseTest.MinimumVersion
 
     [ReleaseTest]

--- a/lib/Minilla/ModuleMaker/ModuleBuild.pm
+++ b/lib/Minilla/ModuleMaker/ModuleBuild.pm
@@ -82,6 +82,12 @@ use <?= $project->build_class ?>;
 use File::Basename;
 use File::Spec;
 
+? if ( @{ $project->unsupported->os } ) {
+?   for my $os ( @{ $project->unsupported->os } ) {
+die "OS unsupported\n" if $^O eq <?= B::perlstring($os) ?>;
+?   }
+
+? }
 ? if ( @{ $project->requires_external_bin || [] } ) {
 use Devel::CheckBin;
 

--- a/lib/Minilla/ModuleMaker/ModuleBuildTiny.pm
+++ b/lib/Minilla/ModuleMaker/ModuleBuildTiny.pm
@@ -105,6 +105,12 @@ use strict;
 
 use Module::Build::Tiny 0.035;
 
+? if ( @{ $project->unsupported->os } ) {
+?   for my $os ( @{ $project->unsupported->os } ) {
+die "OS unsupported\n" if $^O eq <?= B::perlstring($os) ?>;
+?   }
+
+? }
 ? if ( @{ $project->requires_external_bin || [] } ) {
 use Devel::CheckBin;
 

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -18,6 +18,7 @@ use Minilla::Logger;
 use Minilla::Metadata;
 use Minilla::WorkDir;
 use Minilla::ReleaseTest;
+use Minilla::Unsupported;
 use Minilla::ModuleMaker::ModuleBuild;
 use Minilla::ModuleMaker::ModuleBuildTiny;
 use Minilla::ModuleMaker::ExtUtilsMakeMaker;
@@ -130,6 +131,12 @@ sub authors {
         return $meta->authors;
     }
     $self->config->{authors} || $self->metadata->authors;
+}
+
+sub unsupported {
+    my $self = shift;
+    my $unsupported = $self->config->{unsupported} || {};
+    return Minilla::Unsupported->new(%$unsupported);
 }
 
 sub abstract {

--- a/lib/Minilla/Unsupported.pm
+++ b/lib/Minilla/Unsupported.pm
@@ -1,0 +1,16 @@
+package Minilla::Unsupported;
+use strict;
+use warnings;
+use utf8;
+
+use Moo;
+
+has os => (
+    is      => 'ro',
+    isa     => sub { ref $_[0] eq 'ARRAY' },
+    default => sub { [] },
+);
+
+no Moo;
+
+1;

--- a/t/module_maker/eumm/unsupported.t
+++ b/t/module_maker/eumm/unsupported.t
@@ -1,0 +1,45 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use lib "t/lib";
+use Util;
+
+use Minilla::Profile::ModuleBuild;
+use Minilla::Project;
+
+test(sub {
+    my $mf = slurp('Makefile.PL');
+    like($mf, qr{^use ExtUtils::MakeMaker 7\.26;$}m);
+    like($mf, qr{^os_unsupported if \$\^O eq "MSWin32";$}m);
+});
+
+done_testing;
+
+sub test {
+    my $code = shift;
+
+    my $guard = pushd(tempdir());
+
+    Minilla::Profile::ModuleBuild->new(
+        author => 'hoge',
+        dist => 'Acme-Foo',
+        module => 'Acme::Foo',
+        path => 'Acme/Foo.pm',
+        version => '0.01',
+    )->generate();
+
+    spew('MANIFEST', <<'...');
+    Build.PL
+    lib/Acme/Foo.pm
+...
+    write_minil_toml({
+        name => 'Acme-Foo',
+        module_maker => "ExtUtilsMakeMaker",
+        unsupported => { os => [qw/MSWin32/] },
+    });
+    git_init_add_commit();
+    Minilla::Project->new()->regenerate_files();
+    git_init_add_commit();
+    $code->();
+}

--- a/t/module_maker/tiny/unsupported.t
+++ b/t/module_maker/tiny/unsupported.t
@@ -1,0 +1,43 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use lib "t/lib";
+use Util;
+
+use Minilla::Profile::ModuleBuild;
+use Minilla::Project;
+
+test(sub {
+    like(slurp('Build.PL'), qr{^die "OS unsupported\\n" if \$\^O eq "MSWin32";$}m);
+});
+
+done_testing;
+
+sub test {
+    my $code = shift;
+
+    my $guard = pushd(tempdir());
+
+    Minilla::Profile::ModuleBuild->new(
+        author => 'hoge',
+        dist => 'Acme-Foo',
+        module => 'Acme::Foo',
+        path => 'Acme/Foo.pm',
+        version => '0.01',
+    )->generate();
+
+    spew('MANIFEST', <<'...');
+    Build.PL
+    lib/Acme/Foo.pm
+...
+    write_minil_toml({
+        name => 'Acme-Foo',
+        module_maker => "ModuleBuildTiny",
+        unsupported => { os => [qw/MSWin32/] },
+    });
+    git_init_add_commit();
+    Minilla::Project->new()->regenerate_files();
+    git_init_add_commit();
+    $code->();
+}

--- a/t/module_maker/unsupported.t
+++ b/t/module_maker/unsupported.t
@@ -1,0 +1,43 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use lib "t/lib";
+use Util;
+
+use Minilla::Profile::ModuleBuild;
+use Minilla::Project;
+
+test(sub {
+    like(slurp('Build.PL'), qr{^die "OS unsupported\\n" if \$\^O eq "MSWin32";$}m);
+});
+
+done_testing;
+
+sub test {
+    my $code = shift;
+
+    my $guard = pushd(tempdir());
+
+    Minilla::Profile::ModuleBuild->new(
+        author => 'hoge',
+        dist => 'Acme-Foo',
+        module => 'Acme::Foo',
+        path => 'Acme/Foo.pm',
+        version => '0.01',
+    )->generate();
+
+    spew('MANIFEST', <<'...');
+    Build.PL
+    lib/Acme/Foo.pm
+...
+    write_minil_toml({
+        name => 'Acme-Foo',
+        module_maker => "ModuleBuild",
+        unsupported => { os => [qw/MSWin32/] },
+    });
+    git_init_add_commit();
+    Minilla::Project->new()->regenerate_files();
+    git_init_add_commit();
+    $code->();
+}

--- a/t/project/unsupported.t
+++ b/t/project/unsupported.t
@@ -1,0 +1,65 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use lib "t/lib";
+use Util;
+
+use CPAN::Meta;
+
+use Minilla::Profile::Default;
+use Minilla::Project;
+use Minilla::Git;
+use CPAN::Meta;
+use File::Spec;
+
+subtest 'unsupported' => sub {
+    my $guard = pushd(tempdir());
+
+    my $profile = Minilla::Profile::Default->new(
+        author => 'Tokuhiro Matsuno',
+        dist => 'Acme-Foo',
+        path => 'Acme/Foo.pm',
+        suffix => 'Foo',
+        module => 'Acme::Foo',
+        version => '0.01',
+        email => 'tokuhirom@example.com',
+    );
+    $profile->generate();
+    write_minil_toml({
+        name => 'Acme-Foo',
+        unsupported => {
+            os => [qw/MSWin32/],
+        },
+    });
+
+    git_init_add_commit();
+
+    my $project = Minilla::Project->new();
+    is @{ $project->unsupported->os }, 1;
+    is $project->unsupported->os->[0], 'MSWin32';
+};
+
+subtest 'empty unsupported' => sub {
+    my $guard = pushd(tempdir());
+
+    my $profile = Minilla::Profile::Default->new(
+        author => 'Tokuhiro Matsuno',
+        dist => 'Acme-Foo',
+        path => 'Acme/Foo.pm',
+        suffix => 'Foo',
+        module => 'Acme::Foo',
+        version => '0.01',
+        email => 'tokuhirom@example.com',
+    );
+    $profile->generate();
+    write_minil_toml('Acme-Foo');
+
+    git_init_add_commit();
+
+    my $project = Minilla::Project->new();
+    is @{ $project->unsupported->os }, 0;
+};
+
+done_testing;
+


### PR DESCRIPTION
`os_unsupported` API is added on EUMM 7.26.
By setting `unsupported.os` value to add unsupported OS checks for (Build.PL|Makefile.PL).