### PR TITLE
fix permissions test at dev version release

### DIFF
--- a/lib/Minilla/ReleaseTest.pm
+++ b/lib/Minilla/ReleaseTest.pm
@@ -121,4 +121,4 @@ use Test::More;
 eval q{ use Test::PAUSE::Permissions 0.04 };
 plan skip_all => "Test::PAUSE::Permissions is not installed." if $@;
 
-all_permissions_ok();
+all_permissions_ok({dev => 1});


### PR DESCRIPTION
`minil release` failed author tests at dev version release (e.g. `0.02_01`) as below:

```
t/00_compile.t ................ ok
xt/minilla/cpan_meta.t ........ ok
xt/minilla/minimum_version.t .. ok
xt/minilla/permissions.t ...... skipped: (no reason given)
xt/minilla/pod.t .............. ok
xt/minilla/spelling.t ......... skipped: no ~/.spellunker.en

Test Summary Report
-------------------
xt/minilla/permissions.t    (Wstat: 65280 Tests: 0 Failed: 0)
  Non-zero exit status: 255
Files=6, Tests=7, 160 wallclock secs ( 0.03 usr  0.02 sys +  2.92 cusr  0.75 csys =  3.72 CPU)
Result: FAIL
```

`Test::PAUSE::Permissions` provides an option for dev version release and I fixed to set dev mode in `xt/minilla/permissions.t`.