### PR TITLE
Set x_static_install 1 if it is appropriate

### DIFF
--- a/lib/Minilla.pm
+++ b/lib/Minilla.pm
@@ -401,10 +401,19 @@ module must subclass L<Pod::Markdown>.
 =item Metadata
 
     [Metadata]
-    x_static_install = 1
     x_deprecated = 1
 
 Add arbitrary keys to C<META.json>/C<META.yml>.
+
+=item static_install
+
+    static_install = "auto"
+
+If C<static_install = "auto"> (or nothing is specified at all),
+then minil tries to detect whether distributions are ready for static install or not, and set C<x_static_install> in META files accordingly.
+You can also set C<static_install = 0/1> explicitly; then minil will respect it.
+
+For static install itself, please refer to L<https://github.com/Perl-Toolchain-Gang/cpan-static>.
 
 =back
 

--- a/lib/Minilla/CLI/New.pm
+++ b/lib/Minilla/CLI/New.pm
@@ -77,6 +77,7 @@ sub run {
         # generate project after initialize git repo
         my $project = Minilla::Project->new();
         $project->generate_minil_toml($profile);
+        cmd('git', 'add', '.');
         $project->regenerate_files();
 
         # and git add all things

--- a/t/project/static_install.t
+++ b/t/project/static_install.t
@@ -1,0 +1,125 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use lib "t/lib";
+use Util;
+
+use Minilla;
+use Minilla::Project;
+use Minilla::CLI::New;
+use CPAN::Meta;
+use TOML qw(from_toml to_toml);
+
+subtest basic => sub {
+    my $guard = pushd(tempdir());
+    Minilla::CLI::New->run('Acme::Foo');
+    chdir "Acme-Foo";
+
+    my ($config, $meta);
+    $config = from_toml slurp("minil.toml");
+    is $config->{static_install}, "auto";
+
+    $meta = CPAN::Meta->load_file("META.json")->as_struct;
+    is $meta->{x_static_install}, 1;
+
+    $config->{static_install} = 0;
+    spew("minil.toml", to_toml $config);
+    Minilla::Project->new->regenerate_files;
+    $meta = CPAN::Meta->load_file("META.json")->as_struct;
+    is $meta->{x_static_install}, 0;
+
+    $config->{static_install} = 1;
+    spew("minil.toml", to_toml $config);
+    Minilla::Project->new->regenerate_files;
+    $meta = CPAN::Meta->load_file("META.json")->as_struct;
+    is $meta->{x_static_install}, 1;
+};
+
+my $static_install = sub {
+    my $sub = shift;
+    my $guard = pushd(tempdir());
+    Minilla::CLI::New->run('Acme::Foo');
+    chdir "Acme-Foo";
+    $sub->();
+    git_add(".");
+    Minilla::Project->new->regenerate_files;
+    git_add(".");
+    CPAN::Meta->load_file("META.json")->as_struct->{x_static_install};
+};
+
+subtest auto_detection => sub {
+    my $test;
+
+    $test = sub {
+        mkdir "script";
+        spew "script/foo", "#!perl\nprint 'hello'\n";
+    };
+    is $static_install->($test), 1;
+
+    $test = sub {
+        mkdir "share";
+        spew "share/foo", "this is a share file";
+    };
+    is $static_install->($test), 1;
+
+    $test = sub {
+        my $config = from_toml slurp "minil.toml";
+        $config->{module_maker} = "ExtUtilsMakeMaker";
+        spew "minil.toml", to_toml $config;
+    };
+    is $static_install->($test), 1;
+
+    $test = sub {
+        mkdir "bin";
+        spew "bin/foo", "#!perl\nprint 'hello'\n";
+    };
+    is $static_install->($test), 0;
+
+    $test = sub {
+        spew "lib/Acme/Foo.xs", "/* this is a xs code */\n";
+    };
+    is $static_install->($test), 0;
+
+    $test = sub {
+        my $config = from_toml slurp "minil.toml";
+        $config->{requires_external_bin} = ["git"];
+        spew "minil.toml", to_toml $config;
+    };
+    is $static_install->($test), 0;
+
+    $test = sub {
+        my $config = from_toml slurp "minil.toml";
+        $config->{unsupported}{os} = ["MSWin32"];
+        spew "minil.toml", to_toml $config;
+    };
+    is $static_install->($test), 0;
+
+    $test = sub {
+        my $config = from_toml slurp "minil.toml";
+        $config->{build}{build_class} = 'builder::MyBuilder';
+        spew "minil.toml", to_toml $config;
+        mkdir "builder";
+        spew "builder/MyBuilder", q{
+            package builder::MyBuilder;
+            use base 'Module::Build';
+        };
+    };
+    is $static_install->($test), 0;
+
+    $test = sub {
+        spew "lib/Acme/Bar.pm.PL", "# this is a PL file\n";
+    };
+    is $static_install->($test), 0;
+
+    $test = sub {
+        my $config = from_toml slurp "minil.toml";
+        $config->{PL_files}{"Bar.pm.PL"} = "lib/Acme/Bar.pm";
+        $config->{module_maker} = "ModuleBuild";
+        spew "minil.toml", to_toml $config;
+        spew "Bar.pm.PL", "# this is a PL file\n";
+    };
+    is $static_install->($test), 0;
+};
+
+done_testing;


### PR DESCRIPTION
Now milla sets x_static_install 1 if it is appropriate.
https://metacpan.org/release/MIYAGAWA/Dist-Milla-v1.0.19

I am happy if Minilla follows that.

In this PR:
If `static_install = "auto"` is specified in minil.toml (or nothing is specified), then minil tries to detect whether distributions are ready for static install or not, and set `x_static_install` accordingly.
If users specify `static_install = 0/1` explicitly, then minil will respect it.

@tokuhirom Feel free to reject this PR.

See also
* The spec of static install: https://github.com/Perl-Toolchain-Gang/cpan-static
* A Dist::Zilla plugin for static install: https://metacpan.org/pod/Dist::Zilla::Plugin::StaticInstall