### PR TITLE
Only extract authors from =head1

### DIFF
--- a/lib/Minilla/Metadata.pm
+++ b/lib/Minilla/Metadata.pm
@@ -101,7 +101,7 @@ sub _build_authors {
 
     my $content = slurp_utf8($self->source);
     if ($content =~ m/
-        =head \d \s+ (?:authors?)\b \s*
+        =head1 \s+ (?:authors?)\b \s*
         ([^\n]*)
         |
         =head \d \s+ (?:licen[cs]e|licensing|copyright|legal)\b \s*


### PR DESCRIPTION
This fixes the case where "authors" might accidentally get extracted from the description for a function named 'author'.

Ref #240 