### PR TITLE
remove temp directories in test

### DIFF
--- a/t/cli/build.t
+++ b/t/cli/build.t
@@ -7,7 +7,7 @@ use Util;
 use Minilla::Profile::ModuleBuild;
 use Minilla::CLI::Build;
 
-my $guard = pushd(tempdir());
+my $guard = pushd(tempdir(CLEANUP => 1));
 
 {
     Minilla::Profile::ModuleBuild->new(

--- a/t/cli/clean.t
+++ b/t/cli/clean.t
@@ -6,7 +6,7 @@ use lib "t/lib";
 use Util;
 use Minilla::CLI::Clean;
 
-my $guard = pushd(tempdir());
+my $guard = pushd(tempdir(CLEANUP => 1));
 
 {
     write_minil_toml({

--- a/t/cli/regenerate_BuildPL.t
+++ b/t/cli/regenerate_BuildPL.t
@@ -16,7 +16,7 @@ sub regenerate_BuildPL_test {
     my $fork  = $opt{fork};
     my $repo  = $opt{repo};
 
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
     Minilla::CLI::New->run("Acme::Foo");
 
     {
@@ -55,7 +55,7 @@ sub regenerate_BuildPL_test {
 }
 
 {
-    my $repo = tempdir();
+    my $repo = tempdir(CLEANUP => 1);
     { my $guard = pushd($repo); cmd('git', 'init', '--bare'); }
     local $ENV{PERL_MM_USE_DEFAULT} = 1;
     local $ENV{PERL_MINILLA_SKIP_CHECK_CHANGE_LOG} = 1;

--- a/t/cli/release.t
+++ b/t/cli/release.t
@@ -8,13 +8,13 @@ use Util;
 use Minilla::Profile::ModuleBuild;
 use Minilla::CLI::Release;
 
-my $repo = tempdir();
+my $repo = tempdir(CLEANUP => 1);
 {
     my $guard = pushd($repo);
     cmd('git', 'init', '--bare');
 }
 
-my $guard = pushd(tempdir());
+my $guard = pushd(tempdir(CLEANUP => 1));
 
 Minilla::Profile::ModuleBuild->new(
     author => 'hoge',

--- a/t/cli/release_no_pause_file.t
+++ b/t/cli/release_no_pause_file.t
@@ -9,13 +9,13 @@ use Minilla::Profile::ModuleBuild;
 use Minilla::CLI::Release;
 use Carp;
 
-my $repo = tempdir();
+my $repo = tempdir(CLEANUP => 1);
 {
     my $guard = pushd($repo);
     cmd('git', 'init', '--bare');
 }
 
-my $guard = pushd(tempdir());
+my $guard = pushd(tempdir(CLEANUP => 1));
 
 Minilla::Profile::ModuleBuild->new(
     author => 'hoge',

--- a/t/cli/release_notest.t
+++ b/t/cli/release_notest.t
@@ -9,13 +9,13 @@ use Minilla::Profile::ModuleBuild;
 use Minilla::CLI::Release;
 use Test::Output;
 
-my $repo = tempdir();
+my $repo = tempdir(CLEANUP => 1);
 {
     my $guard = pushd($repo);
     cmd('git', 'init', '--bare');
 }
 
-my $guard = pushd(tempdir());
+my $guard = pushd(tempdir(CLEANUP => 1));
 
 Minilla::Profile::ModuleBuild->new(
     author => 'hoge',

--- a/t/cli/release_with_hooks.t
+++ b/t/cli/release_with_hooks.t
@@ -12,13 +12,13 @@ if (system('which touch') != 0) {
     plan skip_all => "touch: command not found";
 }
 
-my $repo = tempdir();
+my $repo = tempdir(CLEANUP => 1);
 {
     my $guard = pushd($repo);
     cmd('git', 'init', '--bare');
 }
 
-my $guard = pushd(tempdir());
+my $guard = pushd(tempdir(CLEANUP => 1));
 
 Minilla::Profile::ModuleBuild->new(
     author => 'hoge',

--- a/t/filegatherer.t
+++ b/t/filegatherer.t
@@ -48,7 +48,7 @@ subtest 'FileGatherer' => sub {
 done_testing;
 
 sub init {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
     my %submodule_repos = map { $_ => create_submodule_repo($_) } qw/foo bar/;
 
     mkdir 'local';
@@ -76,7 +76,7 @@ sub init {
 sub create_submodule_repo {
     my $name = shift;
 
-    my $dir = tempdir();
+    my $dir = tempdir(CLEANUP => 1);
     my $guard = pushd($dir);
 
     spew("$name.c", '...');

--- a/t/filegatherer/submodules-recursive.t
+++ b/t/filegatherer/submodules-recursive.t
@@ -48,7 +48,7 @@ subtest 'FileGatherer' => sub {
 done_testing;
 
 sub init {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
     my %submodule_repos = map { $_ => create_deep_submodule_repo($_) } qw/foo bar/;
 
     mkdir 'local';
@@ -92,7 +92,7 @@ sub create_deep_submodule_repo {
 sub create_submodule_repo {
     my $name = shift;
 
-    my $dir = tempdir();
+    my $dir = tempdir(CLEANUP => 1);
     my $guard = pushd($dir);
 
     spew("$name.c", '...');

--- a/t/lib/Util.pm
+++ b/t/lib/Util.pm
@@ -22,7 +22,7 @@ $Minilla::DEBUG=1 if $ENV{MINILLA_DEBUG};
 plan skip_all => "No git command" unless which('git');
 plan skip_all => "No cpanm command" unless which('cpanm');
 plan skip_all => "No git configuration" unless `git config user.email` =~ /\@/;
-$ENV{PERL_CPANM_HOME} = tempdir();
+$ENV{PERL_CPANM_HOME} = tempdir(CLEANUP => 1);
 delete $ENV{GIT_CONFIG};
 
 our @EXPORT = (

--- a/t/migrate/changes.t
+++ b/t/migrate/changes.t
@@ -23,7 +23,7 @@ use Minilla::Migrate;
 use Minilla::Git;
 
 subtest 'Insert {{$NEXT}}' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Changes->new(
         author => 'foo',
@@ -48,7 +48,7 @@ subtest 'Insert {{$NEXT}}' => sub {
 };
 
 subtest 'Do not {{$NEXT}} twice' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Changes->new(
         author => 'foo',

--- a/t/migrate/dzil.t
+++ b/t/migrate/dzil.t
@@ -8,6 +8,7 @@ use Test::Requires {
     'Dist::Zilla' => 4.300039
 };
 use File::Which;
+use Cwd 'getcwd';
 
 plan skip_all => "No dzil command" unless which 'dzil';
 plan skip_all => "No git configuration" unless `git config user.email` =~ /\@/;
@@ -21,9 +22,10 @@ use Minilla::Git;
 
 @INC = map { File::Spec->rel2abs($_) } @INC;
 
-my $tmp = tempdir(CLEANUP => 0);
+my $tmp = tempdir(CLEANUP => 1);
 rcopy('t/migrate/dzil/' => $tmp);
 my $dst = File::Spec->catdir($tmp, 'Acme-Dzil');
+my $cwd = getcwd;
 chdir $dst;
 git_init();
 git_add('.');
@@ -42,5 +44,6 @@ for (qw(Build.PL cpanfile minil.toml)) {
     note slurp($_);
 }
 
+chdir $cwd; # this is need for File::Temp
 done_testing;
 

--- a/t/migrate/eumm.t
+++ b/t/migrate/eumm.t
@@ -23,7 +23,7 @@ use Minilla::Migrate;
 use Minilla::Git;
 
 subtest 'Removing committed README' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::EUMM->new(
         author => 'foo',

--- a/t/migrate/no-changes.t
+++ b/t/migrate/no-changes.t
@@ -23,7 +23,7 @@ use Minilla::Migrate;
 use Minilla::Git;
 
 subtest 'No Changes' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = __PACKAGE__->new(
         author => 'foo',

--- a/t/migrate/no-pod.t
+++ b/t/migrate/no-pod.t
@@ -23,7 +23,7 @@ use Minilla::Migrate;
 use Minilla::Git;
 
 subtest 'No Changes' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = __PACKAGE__->new(
         author => 'foo',

--- a/t/migrate/tmpfiles.t
+++ b/t/migrate/tmpfiles.t
@@ -22,7 +22,7 @@ use Minilla::Migrate;
 use Minilla::Git;
 
 subtest 'Removing committed README' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Tempfiles->new(
         author => 'foo',
@@ -47,7 +47,7 @@ subtest 'Removing committed README' => sub {
 };
 
 subtest 'Removing ignored README' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Tempfiles->new(
         author => 'foo',

--- a/t/module_maker/PL_files.t
+++ b/t/module_maker/PL_files.t
@@ -17,7 +17,7 @@ done_testing;
 sub test {
     my $code = shift;
 
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     Minilla::Profile::ModuleBuild->new(
         author => 'hoge',

--- a/t/module_maker/allow_pureperl.t
+++ b/t/module_maker/allow_pureperl.t
@@ -25,7 +25,7 @@ sub test {
     my $allow = shift;
     my $code = shift;
 
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     Minilla::Profile::ModuleBuild->new(
         author => 'hoge',

--- a/t/module_maker/c_source.t
+++ b/t/module_maker/c_source.t
@@ -20,7 +20,7 @@ done_testing;
 sub test {
     my ($c_source, $code) = @_;
 
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     Minilla::Profile::ModuleBuild->new(
         author => 'hoge',

--- a/t/module_maker/eumm/unsupported.t
+++ b/t/module_maker/eumm/unsupported.t
@@ -19,7 +19,7 @@ done_testing;
 sub test {
     my $code = shift;
 
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     Minilla::Profile::ModuleBuild->new(
         author => 'hoge',

--- a/t/module_maker/requires_external_bin.t
+++ b/t/module_maker/requires_external_bin.t
@@ -15,7 +15,7 @@ use Minilla::Project;
 use Minilla::Git;
 
 subtest 'develop deps' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::ModuleBuild->new(
         author => 'Tokuhiro Matsuno',

--- a/t/module_maker/tap_harness_args.t
+++ b/t/module_maker/tap_harness_args.t
@@ -17,7 +17,7 @@ done_testing;
 sub test {
     my $code = shift;
 
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     Minilla::Profile::ModuleBuild->new(
         author => 'hoge',

--- a/t/module_maker/tiny/requires_external_bin.t
+++ b/t/module_maker/tiny/requires_external_bin.t
@@ -15,7 +15,7 @@ use Minilla::Project;
 use Minilla::Git;
 
 subtest 'develop deps' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::ModuleBuildTiny->new(
         author => 'Tokuhiro Matsuno',

--- a/t/module_maker/tiny/unsupported.t
+++ b/t/module_maker/tiny/unsupported.t
@@ -17,7 +17,7 @@ done_testing;
 sub test {
     my $code = shift;
 
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     Minilla::Profile::ModuleBuild->new(
         author => 'hoge',

--- a/t/module_maker/unsupported.t
+++ b/t/module_maker/unsupported.t
@@ -17,7 +17,7 @@ done_testing;
 sub test {
     my $code = shift;
 
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     Minilla::Profile::ModuleBuild->new(
         author => 'hoge',

--- a/t/module_maker/xsutil.t
+++ b/t/module_maker/xsutil.t
@@ -58,7 +58,7 @@ sub test {
     my $xsutil = shift;
     my $code   = shift;
 
-    my $guard = pushd( tempdir() );
+    my $guard = pushd( tempdir(CLEANUP => 1) );
 
     Minilla::Profile::ModuleBuild->new(
         author  => 'hoge',

--- a/t/profile-xs.t
+++ b/t/profile-xs.t
@@ -14,7 +14,7 @@ use Minilla::Git;
 use Minilla::Profile::XS;
 use Minilla::Project;
 
-my $guard = pushd(tempdir(CLEANUP => 0));
+my $guard = pushd(tempdir(CLEANUP => 1));
 
 Minilla::Profile::XS->new(
     dist => 'Acme-Foo',

--- a/t/profile/module-build.t
+++ b/t/profile/module-build.t
@@ -8,7 +8,7 @@ use Util;
 use Minilla::Profile::ModuleBuild;
 use Minilla::Project;
 
-my $guard = pushd(tempdir());
+my $guard = pushd(tempdir(CLEANUP => 1));
 
 Minilla::Profile::ModuleBuild->new(
     author => 'hoge',

--- a/t/project/badge.t
+++ b/t/project/badge.t
@@ -11,7 +11,7 @@ use Minilla::Profile::Default;
 use Minilla::Project;
 
 subtest 'Badge' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Default->new(
         author => 'foo',
@@ -99,7 +99,7 @@ subtest 'Badge' => sub {
     };
 
     subtest 'AppVeyor repository rename' => sub {
-        my $guard   = pushd( tempdir() );
+        my $guard   = pushd( tempdir(CLEANUP => 1) );
         my $profile = Minilla::Profile::Default->new(
             dist    => 'Hashids',
             path    => 'Hashids.pm',

--- a/t/project/contributors.t
+++ b/t/project/contributors.t
@@ -17,7 +17,7 @@ subtest 'develop deps' => sub {
     delete $ENV{GIT_AUTHOR_NAME};
     delete $ENV{GIT_AUTHOR_EMAIL};
 
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Default->new(
         author => 'Tokuhiro Matsuno',

--- a/t/project/detect_source_path.t
+++ b/t/project/detect_source_path.t
@@ -8,7 +8,7 @@ use Util;
 use Minilla;
 use Minilla::Project;
 
-my $guard = pushd(tempdir());
+my $guard = pushd(tempdir(CLEANUP => 1));
 
 spew('minil.toml', <<'...');
 name = "foo-bar"

--- a/t/project/format_tag.t
+++ b/t/project/format_tag.t
@@ -16,7 +16,7 @@ use Minilla::Project;
 use CPAN::Meta::Validator;
 
 subtest 'basic' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Default->new(
         author => 'foo',
@@ -37,7 +37,7 @@ subtest 'basic' => sub {
 };
 
 subtest 'customized' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Default->new(
         author => 'foo',

--- a/t/project/from.t
+++ b/t/project/from.t
@@ -12,7 +12,7 @@ use Minilla::Project;
 use Minilla::Git;
 
 subtest 'abstract_from' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Default->new(
         author => 'Tokuhiro Matsuno',

--- a/t/project/license.t
+++ b/t/project/license.t
@@ -13,7 +13,7 @@ use Minilla::Project;
 use Minilla::Git;
 
 subtest 'develop deps' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Default->new(
         author => 'Tokuhiro Matsuno',

--- a/t/project/meta.t
+++ b/t/project/meta.t
@@ -19,7 +19,7 @@ use JSON qw(decode_json);
 use version;
 
 subtest 'develop deps' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Default->new(
         author => 'foo',
@@ -64,7 +64,7 @@ subtest 'resources' => sub {
     my $prepare_meta_json_resources = sub {
         my $git_conf_url = shift;
 
-        my $guard = pushd(tempdir());
+        my $guard = pushd(tempdir(CLEANUP => 1));
 
         my $profile = Minilla::Profile::Default->new(
             author => 'Tokuhiro Matsuno',
@@ -179,7 +179,7 @@ subtest 'resources' => sub {
 };
 
 subtest 'Metadata' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Default->new(
         author => 'foo',
@@ -209,7 +209,7 @@ subtest 'Metadata' => sub {
 };
 
 subtest perl_version => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Default->new(
         author => 'foo',

--- a/t/project/meta_no_index.t
+++ b/t/project/meta_no_index.t
@@ -8,7 +8,7 @@ use Util;
 use Minilla;
 use Minilla::Project;
 
-my $guard = pushd(tempdir());
+my $guard = pushd(tempdir(CLEANUP => 1));
 
 spew('minil.toml', <<'...');
 name = "foo-bar"

--- a/t/project/script_files.t
+++ b/t/project/script_files.t
@@ -8,7 +8,7 @@ use Util;
 use Minilla;
 use Minilla::Project;
 
-my $guard = pushd(tempdir());
+my $guard = pushd(tempdir(CLEANUP => 1));
 
 spew('minil.toml', <<'...');
 name = "foo-bar"

--- a/t/project/unstable.t
+++ b/t/project/unstable.t
@@ -14,7 +14,7 @@ use CPAN::Meta;
 use File::Spec;
 
 subtest 'unstable' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Default->new(
         author => 'Tokuhiro Matsuno',

--- a/t/project/unsupported.t
+++ b/t/project/unsupported.t
@@ -14,7 +14,7 @@ use CPAN::Meta;
 use File::Spec;
 
 subtest 'unsupported' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Default->new(
         author => 'Tokuhiro Matsuno',
@@ -41,7 +41,7 @@ subtest 'unsupported' => sub {
 };
 
 subtest 'empty unsupported' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Default->new(
         author => 'Tokuhiro Matsuno',

--- a/t/project/xsutil.t
+++ b/t/project/xsutil.t
@@ -12,7 +12,7 @@ use Minilla::Project;
 use Minilla::Git;
 
 subtest 'No xsutil' => sub {
-    my $guard = pushd( tempdir() );
+    my $guard = pushd( tempdir(CLEANUP => 1) );
 
     make_profile();
     write_minil_toml(
@@ -27,7 +27,7 @@ subtest 'No xsutil' => sub {
 
 
 subtest 'Use XSUtil with default value' => sub {
-    my $guard = pushd( tempdir() );
+    my $guard = pushd( tempdir(CLEANUP => 1) );
 
     make_profile();
     write_minil_toml(
@@ -48,7 +48,7 @@ subtest 'Use XSUtil with default value' => sub {
 };
 
 subtest 'Use XSUtil with specify value' => sub {
-    my $guard = pushd( tempdir() );
+    my $guard = pushd( tempdir(CLEANUP => 1) );
 
     make_profile();
     write_minil_toml(

--- a/t/release_test/config.t
+++ b/t/release_test/config.t
@@ -12,7 +12,7 @@ use Minilla::Project;
 
 subtest 'ReleaseTest.MinimumVersion' => sub {
     subtest 'no minimumversion' => sub {
-        my $guard = pushd(tempdir());
+        my $guard = pushd(tempdir(CLEANUP => 1));
 
         my $project = create_project();
 
@@ -32,7 +32,7 @@ MinimumVersion = false
     };
 
     subtest 'normal case' => sub {
-        my $guard = pushd(tempdir());
+        my $guard = pushd(tempdir(CLEANUP => 1));
 
         my $project = create_project();
 

--- a/t/work_dir/_rewrite_pod.t
+++ b/t/work_dir/_rewrite_pod.t
@@ -13,7 +13,7 @@ use Minilla::Git;
 plan skip_all => 'Pod rewriting is temporary disabled.';
 
 subtest 'rewrite pod' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Default->new(
         author => 'tokuhirom',

--- a/t/work_dir/copy.t
+++ b/t/work_dir/copy.t
@@ -13,7 +13,7 @@ use Minilla::Project;
 use Minilla::Git;
 
 subtest 'copy' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Default->new(
         author => 'tokuhirom',

--- a/t/work_dir/dist.t
+++ b/t/work_dir/dist.t
@@ -14,7 +14,7 @@ use Minilla::Project;
 use Minilla::Git;
 
 subtest 'dist' => sub {
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Default->new(
         author => 'tokuhirom',

--- a/t/work_dir/release_test.t
+++ b/t/work_dir/release_test.t
@@ -16,7 +16,7 @@ subtest 'Contributors are included in stopwords' => sub {
     delete $ENV{GIT_AUTHOR_NAME};
     delete $ENV{GIT_AUTHOR_EMAIL};
 
-    my $guard = pushd(tempdir());
+    my $guard = pushd(tempdir(CLEANUP => 1));
 
     my $profile = Minilla::Profile::Default->new(
         author => 'tokuhirom',


### PR DESCRIPTION
Currently running tests of Minilla leaves temp directories. This PR fixed this.

Before
```
❯ mkdir tmp
❯ export TMPDIR=$PWD/tmp
❯ prove -lr t xt
...
All tests successful.
Files=58, Tests=214, 70 wallclock secs ( 0.51 usr  0.12 sys + 55.81 cusr  7.55 csys = 63.99 CPU)
Result: PASS

❯ ls -l tmp | head -5
total 568
drwx------ 7 skaji skaji 4096 May 13 19:14 0HvRR1aiNu
drwx------ 6 skaji skaji 4096 May 13 19:15 0iQ_PXytvw
drwx------ 2 skaji skaji 4096 May 13 19:15 0ktm8WltrZ
drwx------ 3 skaji skaji 4096 May 13 19:14 0OUL8DBHk_
```

After
```
❯ rm -rf tmp
❯ mkdir tmp
❯ export TMPDIR=$PWD/tmp
❯ git checkout tempdir-cleanup
❯ prove -lr t xt
...
All tests successful.
Files=58, Tests=214, 68 wallclock secs ( 0.51 usr  0.11 sys + 54.69 cusr  7.68 csys = 62.99 CPU)
Result: PASS

❯ ls -l tmp
total 0
```
