### PR TITLE
minor fix:  do not count file:// repository as github

### DIFF
--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -499,7 +499,7 @@ sub extract_git_info {
     if ( my $registered_url = `git config --get remote.origin.url` ) {
         $registered_url =~ s/\n//g;
         # XXX Make it public clone URL, but this only works with github
-        if ($registered_url =~ /github\.com/) {
+        if ($registered_url !~ m{^file://} && $registered_url =~ /github\.com/) {
             my ($user, $repo) = $registered_url =~ m{
                 github\.com
                 (?:(?::[0-9]+)?/|:)([^/]+)


### PR DESCRIPTION
I develop Minilla in `~/src/github.com/tokuhirom/Minilla` directory.
Then running test emits a lot of warnings:
```
❯ prove -l t/cli/regenerate_BuildPL.t
t/cli/regenerate_BuildPL.t .. Use of uninitialized value $user in concatenation (.) or string at /home/skaji/src/github.com/tokuhirom/Minilla/lib/Minilla/Project.pm line 510.
Use of uninitialized value $repo in concatenation (.) or string at /home/skaji/src/github.com/tokuhirom/Minilla/lib/Minilla/Project.pm line 510.
Use of uninitialized value $user in concatenation (.) or string at /home/skaji/src/github.com/tokuhirom/Minilla/lib/Minilla/Project.pm line 511.
Use of uninitialized value $repo in concatenation (.) or string at /home/skaji/src/github.com/tokuhirom/Minilla/lib/Minilla/Project.pm line 511.
Template error: Use of uninitialized value $user in concatenation (.) or string at /home/skaji/src/github.com/tokuhirom/Minilla/lib/Minilla/Project.pm line 510.
Template error: Use of uninitialized value $repo in concatenation (.) or string at /home/skaji/src/github.com/tokuhirom/Minilla/lib/Minilla/Project.pm line 510.
Template error: Use of uninitialized value $user in concatenation (.) or string at /home/skaji/src/github.com/tokuhirom/Minilla/lib/Minilla/Project.pm line 511.
... 
```
This is because `file://~/src/github.com/tokuhirom/Minilla` is regarded as "github url".
I do not think we should count `file://` as github url.