### PR TITLE
Ask Git for the top level, rather than inferring from .git/

### DIFF
--- a/lib/Minilla/Git.pm
+++ b/lib/Minilla/Git.pm
@@ -5,8 +5,9 @@ use utf8;
 
 use parent qw(Exporter);
 
-our @EXPORT = qw(git_ls_files git_init git_add git_rm git_commit git_config git_remote git_submodule_add git_submodules git_submodule_files);
+our @EXPORT = qw(git_ls_files git_init git_add git_rm git_commit git_config git_remote git_submodule_add git_submodules git_submodule_files git_show_toplevel);
 
+use Minilla::Logger qw(errorf);
 use Minilla::Util qw(cmd);
 
 sub git_init {
@@ -68,6 +69,13 @@ sub git_submodule_files {
         push @files, map "$submodule_name/$_", split /\0/, shift @output;
     }
     return @files;
+}
+
+sub git_show_toplevel {
+    my $top_level = `git rev-parse --show-toplevel`
+        // errorf("Top-level git directory could not be found for %s\n", Cwd::getcwd());
+    chomp $top_level;
+    return $top_level;
 }
 
 1;

--- a/lib/Minilla/Git.pm
+++ b/lib/Minilla/Git.pm
@@ -72,8 +72,12 @@ sub git_submodule_files {
 }
 
 sub git_show_toplevel {
-    my $top_level = `git rev-parse --show-toplevel`
-        // errorf("Top-level git directory could not be found for %s\n", Cwd::getcwd());
+    my $top_level = `git rev-parse --show-toplevel`;
+    if ( $? != 0 ) {
+        errorf("Top-level git directory could not be found for %s: %s\n", Cwd::getcwd(),
+               $? == -1 ? "$!" :
+               $? & 127 ? "git received signal ". ($? & 127) : "git exited ". ($? >> 8))
+    }
     chomp $top_level;
     return $top_level;
 }

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -14,6 +14,7 @@ use Config::Identity::PAUSE;
 use Module::Runtime qw(require_module);
 
 use Minilla;
+use Minilla::Git qw(git_show_toplevel);
 use Minilla::Logger;
 use Minilla::Metadata;
 use Minilla::WorkDir;
@@ -219,13 +220,7 @@ sub cc_warnings{
 
 sub _build_dir {
     my $self = shift;
-
-    my $gitdir = find_dir('.git')
-        or errorf("Current directory is not in git(%s)\n", Cwd::getcwd());
-    $gitdir = File::Spec->rel2abs($gitdir);
-    my $base_dir = dirname($gitdir);
-
-    return $base_dir;
+    return git_show_toplevel();
 }
 
 sub _trigger_dir {

--- a/t/project/in_submodule.t
+++ b/t/project/in_submodule.t
@@ -1,0 +1,73 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use lib "t/lib";
+use Util;
+
+use CPAN::Meta;
+
+use Minilla::Profile::Default;
+use Minilla::Project;
+use Minilla::Git;
+
+subtest 'project_in_submodule' => sub {
+    my $guard = pushd(tempdir(CLEANUP => 1));
+    mkdir('main');
+    mkdir('sub');
+    chdir('sub');
+
+    my $profile = Minilla::Profile::Default->new(
+        author => 'Tokuhiro Matsuno',
+        dist => 'Acme-Foo',
+        path => 'Acme/Foo.pm',
+        suffix => 'Foo',
+        module => 'Acme::Foo',
+        version => '0.01',
+        email => 'tokuhirom@example.com',
+    );
+    $profile->generate();
+    mkpath('lib/Acme/');
+    spew('lib/Acme/Foo.pod' => <<'...');
+__END__
+
+=encoding utf-8
+
+=pod
+
+=head1 NAME
+
+Acme::Foo - Yeah!!
+
+=head1 SYNOPSIS
+
+    Gah
+
+=head1 AUTHORS
+
+author foo
+
+...
+    write_minil_toml({
+        name => 'Acme-Foo',
+        abstract_from => 'lib/Acme/Foo.pod',
+        authors_from => 'lib/Acme/Foo.pod',
+    });
+
+    git_init_add_commit();
+
+    chdir('../main');
+    git_init();
+    git_submodule_add('../sub');
+    git_add('.');
+    git_commit('-m', 'initial import');
+
+    chdir('sub');
+
+    my $project = Minilla::Project->new();
+    is($project->abstract(), 'Yeah!!');
+    is_deeply($project->authors(), ['author foo']);
+};
+
+done_testing;
+


### PR DESCRIPTION
This fixes an issue where `minil` would try to act on the parent module rather than the submodule when in the submodule’s directory.

When inside a Git submodule, `.git` is a file, not a directory.  By asking Git itself for the top level, we don’t have to worry about such complications.