### PR TITLE
support travis-ci.com badge

### DIFF
--- a/lib/Minilla.pm
+++ b/lib/Minilla.pm
@@ -255,9 +255,9 @@ See L<CPAN::Meta::Spec>.
 
 =item badges
 
-    badges = ['travis', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter', 'metacpan', 'kritika']
+    badges = ['travis-ci.com', 'travis-ci.org', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter', 'metacpan', 'kritika']
 
-Embed badges image (e.g. Travis-CI) to README.md. It ought to be array and each elements must be service name. Now, supported services are only 'travis', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter', 'metacpan' and 'kritika'.
+Embed badges image (e.g. Travis-CI) to README.md. It ought to be array and each elements must be service name. Now, supported services are 'travis-ci.com', 'travis-ci.org', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter', 'metacpan' and 'kritika'.
 
 You can send additional parameters as required by your CI provider by including a
 query string along with your service name: e.g. C<travis?token=[YOUR_TOKEN_GOES_HERE]&branch=dev>

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -609,7 +609,7 @@ sub generate_minil_toml {
     my $project_name = $self->_detect_project_name_from_dir;
     my $content      = join("\n",
         qq{name = "$project_name"},
-        qq{# badges = ["travis"]},
+        qq{# badges = ["travis-ci.com"]},
     );
 
     my %pause;
@@ -663,7 +663,7 @@ sub regenerate_readme_md {
             for my $badge (@{$self->badges}) {
                 my $uri = URI->new( $badge );
                 my $service_name = $uri->path;
-                if ($service_name eq 'travis') {
+                if ($service_name =~ /^travis(?:-ci\.(?:org|com))?$/) {
                     my $build_uri = $uri->clone;
                     $build_uri->scheme('https');
                     $build_uri->path("$user_name/$repository_name");
@@ -673,7 +673,9 @@ sub regenerate_readme_md {
                     $image_uri->path("$user_name/$repository_name.svg");
                     my %image_uri_qs = $image_uri->query_form;
                     $image_uri_qs{branch} = 'master' if !defined($image_uri_qs{branch});
-                    if (!defined($image_uri_qs{token})) {
+                    if ($service_name =~ /^travis(?:-ci\.(?:org|com))$/) {
+                        $_->host($service_name) foreach ($build_uri, $image_uri);
+                    } elsif (!defined($image_uri_qs{token})) {
                         $_->host("travis-ci.org") foreach ($build_uri, $image_uri);
                     } else {
                         $_->host("travis-ci.com") foreach ($build_uri, $image_uri);

--- a/minil.toml
+++ b/minil.toml
@@ -1,4 +1,4 @@
 name="Minilla"
 authority = "cpan:TOKUHIROM"
 module_maker = "ModuleBuildTiny"
-badges = ['travis', 'metacpan']
+badges = ['travis-ci.org', 'metacpan']

--- a/t/project/badge.t
+++ b/t/project/badge.t
@@ -39,7 +39,7 @@ subtest 'Badge' => sub {
     subtest 'Badges exist' => sub {
         write_minil_toml({
             name   => 'Acme-Foo',
-            badges => ['travis', 'circleci', 'appveyor', 'coveralls', 'gitter', 'codecov', 'metacpan'],
+            badges => ['travis', 'travis-ci.com', 'circleci', 'appveyor', 'coveralls', 'gitter', 'codecov', 'metacpan'],
         });
         $project->regenerate_files;
 
@@ -48,6 +48,7 @@ subtest 'Badge' => sub {
 
         my $badge_markdowns = [
             "[![Build Status](https://travis-ci.org/tokuhirom/Minilla.svg?branch=master)](https://travis-ci.org/tokuhirom/Minilla)",
+            "[![Build Status](https://travis-ci.com/tokuhirom/Minilla.svg?branch=master)](https://travis-ci.com/tokuhirom/Minilla)",
             "[![Build Status](https://circleci.com/gh/tokuhirom/Minilla.svg)](https://circleci.com/gh/tokuhirom/Minilla)",
             "[![Build Status](https://img.shields.io/appveyor/ci/tokuhirom/Minilla/master.svg?logo=appveyor)](https://ci.appveyor.com/project/tokuhirom/Minilla/branch/master)",
             "[![Coverage Status](https://img.shields.io/coveralls/tokuhirom/Minilla/master.svg?style=flat)](https://coveralls.io/r/tokuhirom/Minilla?branch=master)",


### PR DESCRIPTION
Now travis-ci.com supports the GitHub Checks API, which is available to open source projects.
https://blog.travis-ci.com/2018-05-07-announcing-support-for-github-checks-api-on-travis-ci-com

This PR adds support for travis-ci.com badge to Minilla;
it introduces explicit keywords `travis-ci.com` and `travis-ci.org` for `badges` in minil.toml.
That is,
* `badges = ['travis-ci.com']` generates travis-ci.com badge
* `badges = ['travis-ci.org']` generates travis-ci.org badge

Note that for backward compatibility, `travis` keyword still means travis-ci.org.