### PR TITLE
{{$NEXT}}: support CRLF

### DIFF
--- a/lib/Minilla/Release/CheckChanges.pm
+++ b/lib/Minilla/Release/CheckChanges.pm
@@ -17,7 +17,7 @@ sub run {
         return;
     }
 
-    until (slurp('Changes') =~ /^\{\{\$NEXT\}\}\n+[ \t]+\S/m) {
+    until (slurp('Changes') =~ /^\{\{\$NEXT\}\}\h*\R+\h+\S/m) {
         infof("No mention of {{\$NEXT}} in changelog file 'Changes'\n");
         if (prompt("Edit file?", 'y') =~ /y/i) {
             edit_file('Changes');


### PR DESCRIPTION
Thank you for this tool!  I would like to propose the following patch to the verification of the `Changes` file when you run `minil release`: permit `\r\n` (instead of just `\n`) after the `{{$NEXT}}` tag.  This fixes #259.  This change will make it easier to use Minilla with Windows-based projects.  Thank you for considering this request!