### PR TITLE
{{$NEXT}}: describe detailed error

### DIFF
--- a/lib/Minilla/Release/CheckChanges.pm
+++ b/lib/Minilla/Release/CheckChanges.pm
@@ -17,8 +17,21 @@ sub run {
         return;
     }
 
-    until (slurp('Changes') =~ /^\{\{\$NEXT\}\}\n+[ \t]+\S/m) {
-        infof("No mention of {{\$NEXT}} in changelog file 'Changes'\n");
+    while(1) {
+        my $changes = slurp('Changes');
+        last if $changes =~ /^\{\{\$NEXT\}\}\h*\R+\h+\S/m;
+
+        # Tell the user what the problem is
+        if($changes !~ /\{\{\$NEXT\}\}/m) {
+            infof("No mention of {{\$NEXT}} in changelog file 'Changes'\n");
+        } elsif($changes !~ /^\{\{\$NEXT\}\}/m) {
+            infof("{{\$NEXT}} must be at the beginning of a line in changelog file 'Changes'\n");
+        } elsif($changes !~ /^\{\{\$NEXT\}\}\h*\R/m) {
+            infof("{{\$NEXT}} in changelog file 'Changes' must be the only non-whitespace on its line\n");
+        } else {
+            infof("{{\$NEXT}} in changelog file 'Changes' must be followed by at least one indented line describing a change\n");
+        }
+
         if (prompt("Edit file?", 'y') =~ /y/i) {
             edit_file('Changes');
         } else {
@@ -28,4 +41,3 @@ sub run {
 }
 
 1;
-


### PR DESCRIPTION
When running `minil release`, the `{{$NEXT}}` line in a Changes file must meet all the criteria.  This commit adds code to tell the user what the specific problem is if the `{{$NEXT}}` line does not meet all the criteria.

 For example, 

      {{$NEXT}}

      1.01 2001-02-03
          Some change

is invalid, because there are no changelog entries under `{{$NEXT}}`.  However, the current code says `No mention of {{$NEXT}}`, even though `{{$NEXT}}` is in the file.  I believe this change will reduce user confusion.

This PR also includes the fix in #260, so that it can be applied cleanly after #260. 