### PR TITLE
Added .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = LF


### PR DESCRIPTION
[EditorConfig](https://editorconfig.org) is a cross-platform standard for telling editors about indentation and line-end settings.  The code looks to me like Unix line ends and four-space, non-tab indents.  This file will apply those settings in any EditorConfig-capable editor.  Other editors will ignore it.

Would you be willing to add this file to the repo?  Thanks for considering this request!