### PR TITLE
Use '--cleanup=verbatim' option with commit not to erase empty line in diff output.

### DIFF
--- a/lib/Minilla/Release/Commit.pm
+++ b/lib/Minilla/Release/Commit.pm
@@ -23,7 +23,7 @@ sub run {
         return;
     }
 
-    cmd('git', 'commit', '-a', '-m', $msg);
+    cmd('git', 'commit', '-a', '-m', $msg, '--cleanup=verbatim');
 
     $self->_push_to_origin();
 }


### PR DESCRIPTION
When "Changes" file diff happens to end with empty lines, they are removed by commit command and consequently produce technically inaccurate data.  It also removes trailing spaces at the end of line.

This fix should work fine but "git show/log" command still removes whitespaces before producing output.  It has to be addressed someway but now I can only think of using "git cat-file" to check.