### PR TITLE
It is a conventaion that the remote should be named origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ As stated above, Minilla is opinionated. Minilla has a bold assumption and conve
 
 - Your modules are written in Pure Perl and are located in _lib/_.
 - Your executable files are in _script/_ directory, if any
-- Your module is maintained with **Git** and `git ls-files` matches with what you will release
+- Your module is maintained with **Git**, `git ls-files` matches with what you will release and your remote is named _origin_
 - Your module has a static list of prerequisites that can be described in [cpanfile](https://metacpan.org/pod/cpanfile)
 - Your module has a Changes file
 - Your module requires at least perl 5.6.

--- a/lib/Minilla.pm
+++ b/lib/Minilla.pm
@@ -46,7 +46,7 @@ As stated above, Minilla is opinionated. Minilla has a bold assumption and conve
 
 =item Your executable files are in I<script/> directory, if any
 
-=item Your module is maintained with B<Git> and C<git ls-files> matches with what you will release
+=item Your module is maintained with B<Git>, C<git ls-files> matches with what you will release and your remote is named I<origin>
 
 =item Your module has a static list of prerequisites that can be described in L<cpanfile>
 


### PR DESCRIPTION
Hello,

First thank you a lot for this great tool !!! :heart: 

Some features won't work if your remote is not named origin. 
If you have only one remote but it is named "central", `minil test` won't be able to generate badges for instance.

This pull request is the very minimum (document the convention).

I tried to do more than that (adding a check) but it's not clear what would be the best approach :
- If I add a check in sub **CheckOrigin** (currently only check that a remote is set, not the name of it), it seems it will be only be executed during Release action.
- If I add a check in **check_git** it will be executed for every actions even if some of them do not require to access the remote url.
- We can add another sub **check_git_origin** and add it as a step of some actions (which ones?)
- If there is only one remote and it is not named origin, maybe we can use it instead (require more changes)

In short, I don't know and I would be glad to hear your opinion.
(my current personal favorite approach is the **check_git**)

The pull request at least document the convention which is already a very helpful and make it clear for every user.

Best regards.

Thibault


