### PR TITLE
Add gitlab badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ As stated above, Minilla is opinionated. Minilla has a bold assumption and conve
 
 - Your modules are written in Pure Perl and are located in _lib/_.
 - Your executable files are in _script/_ directory, if any
-- Your module is maintained with **Git**, `git ls-files` matches with what you will release and your remote is named _origin_
+- Your module is maintained with **Git**, `git ls-files` matches with what you will release, your remote is named _origin_ and your main branch is named _master_
 - Your module has a static list of prerequisites that can be described in [cpanfile](https://metacpan.org/pod/cpanfile)
 - Your module has a Changes file
 - Your module requires at least perl 5.6.
@@ -227,9 +227,9 @@ But, you can write configurations to _minil.toml_ file in [TOML](https://github.
 
 - badges
 
-        badges = ['travis-ci.com', 'travis-ci.org', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter', 'metacpan', 'kritika', 'github-actions/$workflow_name']
+        badges = ['travis-ci.com', 'travis-ci.org', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter', 'metacpan', 'kritika', 'github-actions/$workflow_name', 'gitlab-pipeline', 'gitlab-coverage']
 
-    Embed badges image (e.g. Travis-CI) to README.md. It ought to be array and each elements must be service name. Now, supported services are 'travis-ci.com', 'travis-ci.org', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter', 'metacpan' and 'kritika'.
+    Embed badges image (e.g. Travis-CI) to README.md. It ought to be array and each elements must be service name. Now, supported services are 'travis-ci.com', 'travis-ci.org', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter', 'metacpan', 'kritika' 'github-actions', 'gitlab-pipeline' and 'gitlab-coverage'.
 
     You can send additional parameters as required by your CI provider by including a
     query string along with your service name: e.g. `travis?token=[YOUR_TOKEN_GOES_HERE]&branch=dev`

--- a/lib/Minilla.pm
+++ b/lib/Minilla.pm
@@ -46,7 +46,7 @@ As stated above, Minilla is opinionated. Minilla has a bold assumption and conve
 
 =item Your executable files are in I<script/> directory, if any
 
-=item Your module is maintained with B<Git>, C<git ls-files> matches with what you will release and your remote is named I<origin>
+=item Your module is maintained with B<Git>, C<git ls-files> matches with what you will release, your remote is named I<origin> and your main branch is named I<master>
 
 =item Your module has a static list of prerequisites that can be described in L<cpanfile>
 
@@ -256,9 +256,9 @@ See L<CPAN::Meta::Spec>.
 
 =item badges
 
-    badges = ['travis-ci.com', 'travis-ci.org', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter', 'metacpan', 'kritika', 'github-actions/$workflow_name']
+    badges = ['travis-ci.com', 'travis-ci.org', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter', 'metacpan', 'kritika', 'github-actions/$workflow_name', 'gitlab-pipeline', 'gitlab-coverage']
 
-Embed badges image (e.g. Travis-CI) to README.md. It ought to be array and each elements must be service name. Now, supported services are 'travis-ci.com', 'travis-ci.org', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter', 'metacpan' and 'kritika'.
+Embed badges image (e.g. Travis-CI) to README.md. It ought to be array and each elements must be service name. Now, supported services are 'travis-ci.com', 'travis-ci.org', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter', 'metacpan', 'kritika' 'github-actions', 'gitlab-pipeline' and 'gitlab-coverage'.
 
 You can send additional parameters as required by your CI provider by including a
 query string along with your service name: e.g. C<travis?token=[YOUR_TOKEN_GOES_HERE]&branch=dev>

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -712,6 +712,10 @@ sub regenerate_readme_md {
                 } elsif ($service_name =~ m!^github-actions(?:/(.+))?$!) {
                     my $workflow_name = $1 || 'test';
                     push @badges, "[![Actions Status](https://github.com/$user_name/$repository_name/workflows/$workflow_name/badge.svg)](https://github.com/$user_name/$repository_name/actions)";
+                } elsif ($service_name eq 'gitlab-pipeline') {
+                    push @badges, "[![Gitlab pipeline](https://gitlab.com/$user_name/$repository_name/badges/master/pipeline.svg)](https://gitlab.com/$user_name/$repository_name/-/commits/master)";
+                } elsif ($service_name eq 'gitlab-coverage') {
+                    push @badges, "[![Gitlab coverage](https://gitlab.com/$user_name/$repository_name/badges/master/coverage.svg)](https://gitlab.com/$user_name/$repository_name/-/commits/master)";
                 }
             }
         }


### PR DESCRIPTION
Hello,

This pull request adds support for gitlab badges (pipeline and coverage). 
Somebody opened an issue about it : #285  

Currently the link is https://gitlab.com/$user_name/$repository_name/-/commits/master as documented in gitlab settings but we could imagine using also https://gitlab.com/$user_name/$repository_name/pipelines 

Best regards.

Thibault
