### PR TITLE
Add license flag for new subcommand

### DIFF
--- a/lib/Minilla/License/Perl_5.pm
+++ b/lib/Minilla/License/Perl_5.pm
@@ -18,6 +18,18 @@ sub url  { 'http://dev.perl.org/licenses/' }
 sub meta_name  { 'perl' }
 sub meta2_name { 'perl_5' }
 
+sub notice {
+    my $self = shift;
+
+    my $author = $self->holder;
+    <<"..."
+Copyright (C) $author
+
+This library is free software; you can redistribute it and/or modify
+it under the same terms as Perl itself.
+...
+}
+
 sub fulltext {
     my ($self) = @_;
 

--- a/lib/Minilla/Profile/Base.pm
+++ b/lib/Minilla/Profile/Base.pm
@@ -8,8 +8,9 @@ use File::Basename qw(dirname);
 use Data::Section::Simple;
 use Time::Piece;
 
-use Minilla::Util qw(spew_raw);
+use Minilla::Util qw(spew_raw guess_license_class_by_name);
 use Minilla::Logger;
+use Minilla::License::Perl_5;
 
 use Moo;
 
@@ -28,7 +29,7 @@ has suffix => (
     required => 1,
 );
 
-has [qw(email author)] => (
+has [qw(email author license)] => (
     is => 'lazy',
     required => 1,
 );
@@ -46,6 +47,13 @@ sub _build_author {
     }
 
     $name;
+}
+
+sub _build_license {
+    my $self = shift;
+    Minilla::License::Perl_5->new({
+        holder => $self->author,
+    });
 }
 
 sub _build_email {
@@ -119,6 +127,10 @@ sub write_file {
     spew_raw($path, $content);
 }
 
+sub license_notice {
+    my $self = shift;
+    $self->license->notice;
+}
 
 1;
 __DATA__
@@ -162,10 +174,7 @@ our $VERSION = "<% $version %>";
 
 =head1 LICENSE
 
-Copyright (C) <% $author %>.
-
-This library is free software; you can redistribute it and/or modify
-it under the same terms as Perl itself.
+<% $license_notice %>
 
 =head1 AUTHOR
 

--- a/lib/Minilla/Profile/ExtUtilsMakeMaker.pm
+++ b/lib/Minilla/Profile/ExtUtilsMakeMaker.pm
@@ -12,8 +12,6 @@ use CPAN::Meta;
 use Data::Section::Simple qw(get_data_section);
 use File::pushd;
 
-use Minilla::License::Perl_5;
-
 sub generate {
     my $self = shift;
 
@@ -24,9 +22,7 @@ sub generate {
     $self->render('.travis.yml');
 
     $self->render('.gitignore');
-    $self->write_file('LICENSE', Minilla::License::Perl_5->new(
-        holder => sprintf('%s <%s>', $self->author, $self->email)
-    )->fulltext);
+    $self->write_file('LICENSE', $self->license->fulltext);
 
     $self->render('cpanfile');
 }
@@ -40,4 +36,3 @@ requires 'perl', '5.008001';
 on 'test' => sub {
     requires 'Test::More', '0.98';
 };
-

--- a/lib/Minilla/Profile/ModuleBuild.pm
+++ b/lib/Minilla/Profile/ModuleBuild.pm
@@ -12,8 +12,6 @@ use CPAN::Meta;
 use Data::Section::Simple qw(get_data_section);
 use File::pushd;
 
-use Minilla::License::Perl_5;
-
 sub generate {
     my $self = shift;
 
@@ -24,9 +22,7 @@ sub generate {
     $self->render('.travis.yml');
 
     $self->render('.gitignore');
-    $self->write_file('LICENSE', Minilla::License::Perl_5->new(
-        holder => sprintf('%s <%s>', $self->author, $self->email)
-    )->fulltext);
+    $self->write_file('LICENSE', $self->license->fulltext);
 
     $self->render('cpanfile');
 }
@@ -40,4 +36,3 @@ requires 'perl', '5.008001';
 on 'test' => sub {
     requires 'Test::More', '0.98';
 };
-

--- a/lib/Minilla/Profile/ModuleBuildTiny.pm
+++ b/lib/Minilla/Profile/ModuleBuildTiny.pm
@@ -12,8 +12,6 @@ use CPAN::Meta;
 use Data::Section::Simple qw(get_data_section);
 use File::pushd;
 
-use Minilla::License::Perl_5;
-
 sub generate {
     my $self = shift;
 
@@ -24,9 +22,7 @@ sub generate {
     $self->render('.travis.yml');
 
     $self->render('.gitignore');
-    $self->write_file('LICENSE', Minilla::License::Perl_5->new(
-        holder => sprintf('%s <%s>', $self->author, $self->email)
-    )->fulltext);
+    $self->write_file('LICENSE', $self->license->fulltext);
 
     $self->render('cpanfile');
 }
@@ -40,4 +36,3 @@ requires 'perl', '5.008001';
 on 'test' => sub {
     requires 'Test::More', '0.98';
 };
-

--- a/lib/Minilla/Profile/XS.pm
+++ b/lib/Minilla/Profile/XS.pm
@@ -42,9 +42,7 @@ sub generate {
     $gi->add("!$ppport"); # Import ppport.h!
     $gi->save('.gitignore');
 
-    $self->write_file('LICENSE', Minilla::License::Perl_5->new(
-        holder => sprintf('%s <%s>', $self->author, $self->email)
-    )->fulltext);
+    $self->write_file('LICENSE', $self->license->fulltext);
 
     $self->render('cpanfile');
 }

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -603,7 +603,7 @@ sub regenerate_meta_json {
 }
 
 sub generate_minil_toml {
-    my ($self, $profile) = @_;
+    my ($self, $profile, $license) = @_;
 
     my $fname        = File::Spec->catfile($self->dir, 'minil.toml');
     my $project_name = $self->_detect_project_name_from_dir;
@@ -627,6 +627,10 @@ sub generate_minil_toml {
         $content .= qq{\nmodule_maker="ModuleBuildTiny"\n};
     }
     $content .= qq{static_install = "auto"\n};
+
+    if ($license) {
+        $content .= qq{license = "${license}"\n};
+    }
 
     spew_raw($fname, $content . "\n");
 }

--- a/lib/Minilla/Util.pm
+++ b/lib/Minilla/Util.pm
@@ -22,6 +22,7 @@ our @EXPORT_OK = qw(
     pod_escape
     parse_options
     check_git
+    guess_license_class_by_name
 );
 
 our %EXPORT_TAGS = (
@@ -169,5 +170,49 @@ sub check_git {
     }
 }
 
-1;
+sub guess_license_class_by_name {
+    my ($name) = @_;
 
+    if ($name eq 'Perl_5') {
+        return 'Minilla::License::Perl_5';
+    } else {
+        my %license_map = (
+            'agpl_3'       => 'Software::License::AGPL_3',
+            'apache_1_1'   => 'Software::License::Apache_1_1',
+            'apache_2_0'   => 'Software::License::Apache_2_0',
+            'artistic_1'   => 'Software::License::Artistic_1_0',
+            'artistic_2'   => 'Software::License::Artistic_2_0',
+            'bsd'          => 'Software::License::BSD',
+            'unrestricted' => 'Software::License::CC0_1_0',
+            'custom'       => 'Software::License::Custom',
+            'freebsd'      => 'Software::License::FreeBSD',
+            'gfdl_1_2'     => 'Software::License::GFDL_1_2',
+            'gfdl_1_3'     => 'Software::License::GFDL_1_3',
+            'gpl_1'        => 'Software::License::GPL_1',
+            'gpl_2'        => 'Software::License::GPL_2',
+            'gpl_3'        => 'Software::License::GPL_3',
+            'lgpl_2_1'     => 'Software::License::LGPL_2_1',
+            'lgpl_3_0'     => 'Software::License::LGPL_3_0',
+            'mit'          => 'Software::License::MIT',
+            'mozilla_1_0'  => 'Software::License::Mozilla_1_0',
+            'mozilla_1_1'  => 'Software::License::Mozilla_1_1',
+            'open_source'  => 'Software::License::Mozilla_2_0',
+            'restricted'   => 'Software::License::None',
+            'openssl'      => 'Software::License::OpenSSL',
+            'perl_5'       => 'Software::License::Perl_5',
+            'open_source'  => 'Software::License::PostgreSQL',
+            'qpl_1_0'      => 'Software::License::QPL_1_0',
+            'ssleay'       => 'Software::License::SSLeay',
+            'sun'          => 'Software::License::Sun',
+            'zlib'         => 'Software::License::Zlib',
+        );
+        if (my $klass = $license_map{lc $name}) {
+            eval "require $klass; 1" or die "$klass is required for supporting $name license. But: $@"; ## no critic.
+            return $klass;
+        } else {
+            die "'$name' is not supported yet. Supported licenses are: " . join(', ', keys %license_map);
+        }
+    }
+}
+
+1;

--- a/t/new/license.t
+++ b/t/new/license.t
@@ -1,0 +1,24 @@
+use strict;
+use warnings;
+use utf8;
+use Test::More;
+use Test::Requires 'Software::License';
+use lib "t/lib";
+use Util;
+use File::Temp qw(tempdir);
+use File::pushd;
+
+use Minilla::CLI::New;
+use Minilla::CLI;
+
+subtest 'Specify license' => sub {
+    my $guard = pushd(tempdir(CLEANUP => 1));
+    Minilla::CLI::New->run('Acme::Speciality', '--username' => 'foo', '--email' => 'bar', '--license' => 'MIT');
+
+    open my $fh, "Acme-Speciality/README.md";
+    chomp (my $got = do { local $/; <$fh> });
+    like $got, qr{MIT.+License};
+};
+
+done_testing;
+


### PR DESCRIPTION
This is inspired by #282 

We can specify license with this patch as below

```
minil new --license=MIT Foo
```