### PR TITLE
Take author name from AUTHOR section even if it appears later.

### DIFF
--- a/lib/Minilla/Metadata.pm
+++ b/lib/Minilla/Metadata.pm
@@ -101,14 +101,14 @@ sub _build_authors {
 
     my $content = slurp_utf8($self->source);
     if ($content =~ m/
-        =head1 \s+ (?:authors?)\b \s*
-        ([^\n]*)
-        |
-        =head \d \s+ (?:licen[cs]e|licensing|copyright|legal)\b \s*
+        ^=head1 \s+ (?:authors?)\b \s*
+        ([^\n]+)
+    /ixm || $content =~ m/
+        ^=head \d \s+ (?:licen[cs]e|licensing|copyright|legal)\b \s*
         .*? copyright .*? \d\d\d[\d.]+ \s* (?:\bby\b)? \s*
-        ([^\n]*)
+        ([^\n]+)
     /ixms) {
-        my $author = $1 || $2;
+        my $author = $1;
 
         $author =~ s{ E<( (\d+) | ([A-Za-z]+) )> }{
             defined $2

--- a/t/project/in_submodule.t
+++ b/t/project/in_submodule.t
@@ -43,6 +43,10 @@ Acme::Foo - Yeah!!
 
     Gah
 
+=head1 LICENSE
+
+Copyright 2013- by author foo.  All rights reserved.
+
 =head1 AUTHORS
 
 author foo


### PR DESCRIPTION
Currently, the author's name is taken from the LICENSE section if it appears earlier than the AUTHOR section.
I believe it is not intentional behavior.
This code makes it always look at the AUTHOR section if it exists.
I added minimal updates in other regex parts.