### PR TITLE
In CheckOrigin.pm, make sure that there is a remote named 'origin'.

### DIFF
--- a/lib/Minilla/Release/CheckOrigin.pm
+++ b/lib/Minilla/Release/CheckOrigin.pm
@@ -7,8 +7,9 @@ use Minilla::Logger;
 sub run {
     my ($self, $project, $opts) = @_;
 
-    unless (`git remote`) {
-        errorf("No git remote.\n");
+    my $remotes = `git remote`;
+    if ($remotes !~ /^origin$/m) {
+        errorf("No git remote named origin.\n");
     }
 }
 


### PR DESCRIPTION
I add a strict check for the remote name in CheckOrigin because, by convention, Minilla requires that the remote name is "origin".