### PR TITLE
Detect default branch from "origin" and remove the convention of release branch as "master"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ As stated above, Minilla is opinionated. Minilla has a bold assumption and conve
 
 - Your modules are written in Pure Perl and are located in _lib/_.
 - Your executable files are in _script/_ directory, if any
-- Your module is maintained with **Git**, `git ls-files` matches with what you will release, your remote is named _origin_ and your main branch is named _master_
+- Your module is maintained with **Git**, `git ls-files` matches with what you will release and your remote is named _origin_
 - Your module has a static list of prerequisites that can be described in [cpanfile](https://metacpan.org/pod/cpanfile)
 - Your module has a Changes file
 - Your module requires at least perl 5.6.

--- a/lib/Minilla.pm
+++ b/lib/Minilla.pm
@@ -46,7 +46,7 @@ As stated above, Minilla is opinionated. Minilla has a bold assumption and conve
 
 =item Your executable files are in I<script/> directory, if any
 
-=item Your module is maintained with B<Git>, C<git ls-files> matches with what you will release, your remote is named I<origin> and your main branch is named I<master>
+=item Your module is maintained with B<Git>, C<git ls-files> matches with what you will release and your remote is named I<origin>
 
 =item Your module has a static list of prerequisites that can be described in L<cpanfile>
 

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -82,6 +82,11 @@ has files => (
     is => 'lazy',
 );
 
+has release_branch => (
+    is      => 'lazy',
+    clearer => 1,
+);
+
 has no_index => (
     is => 'ro',
     default => sub {
@@ -657,7 +662,7 @@ sub regenerate_readme_md {
         if (my $web_url = $git_info->{repository}->{web}) {
             ($user_name, $repository_name) = $web_url =~ m!https://.+/(.+)/(.+)!;
         }
-        my $branch = $self->config->{release}->{branch} // 'master';
+        my $branch = $self->release_branch;
         my @badges;
         if ($user_name && $repository_name) {
             for my $badge (@{$self->badges}) {
@@ -777,6 +782,18 @@ sub _build_files {
         $self->dir
     );
     \@files;
+}
+
+sub _build_release_branch {
+    my $self = shift;
+    if (my $br = $self->config->{release}->{branch}) {
+        return $br;
+    }
+    my $show = `git remote show origin`;
+    my ($br) = $show =~ /^\s*HEAD branch:\s(\S+)$/m;
+    # For backward compatibility, fallback to 'master' just in case,
+    # but it's unlikely to be used in practice.
+    return $br || 'master';
 }
 
 sub perl_files {

--- a/lib/Minilla/Release/CheckReleaseBranch.pm
+++ b/lib/Minilla/Release/CheckReleaseBranch.pm
@@ -7,6 +7,8 @@ use Minilla::Logger;
 sub run {
     my ($self, $project, $opts) = @_;
 
+    # The checking only performs when the config explicitly sets the release branch.
+    # That's why we don't use "$project->release_branch".
     my $release_branch = $project->config->{release}->{branch};
     return unless $release_branch;
 

--- a/t/project/badge.t
+++ b/t/project/badge.t
@@ -69,6 +69,7 @@ subtest 'Badge' => sub {
                 branch => 'main',
             },
         });
+        $project->clear_release_branch;
         $project->regenerate_files;
 
         open my $fh, '<', 'README.md';
@@ -83,6 +84,8 @@ subtest 'Badge' => sub {
         ];
         my $expected = join(' ', @$badge_markdowns);
         is $got, $expected;
+
+        $project->clear_release_branch;
     };
 
     subtest 'Badges do not exist' => sub {


### PR DESCRIPTION
Minilla initially has a convention that the master branch is the release branch, but that is no longer used except for badge URL generation. Also, the practice of using master as the default branch has depreciated in general.

Therefore, I propose to abolish this convention.

It is enough for the badge URL generation to use the "config.release.branch" or extract the default branch from the output of  `git remote show origin`. I've made those changes.

An unintended side effect of this change is that the generated badge URLs may change, but it is not a critical issue and is acceptable.