### PR TITLE
surppress warnings of Redundant argument in sprintf

### DIFF
--- a/lib/Minilla/Release/BumpVersion.pm
+++ b/lib/Minilla/Release/BumpVersion.pm
@@ -35,7 +35,7 @@ sub run {
                 "The version format doesn't match the current one.\n" .
                 "Continue the release with this version? [y/n]", $ver, $curr_ver;
             if (prompt($msg) !~ /y/i) {
-                errorf("Stop the release due to version format mismatch\n", $ver);
+                errorf("Stop the release due to version format mismatch\n");
             }
         }
 


### PR DESCRIPTION
Sorry. I didn't check it enough and there was a little warning, so I'll fix it. This is the last in my series of fixes. Thank you for all your help.