### PR TITLE
specify repository type

### DIFF
--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -545,6 +545,7 @@ sub extract_git_info {
                 };
             }
             $repository = +{
+                type => "git",
                 url => $git_url,
                 web => $http_url,
             };
@@ -568,6 +569,7 @@ sub extract_git_info {
             # normal repository
             if ($registered_url !~ m{^file://}) {
                 $repository = +{
+                    type => "git",
                     url => $registered_url,
                 };
             }

--- a/t/project/meta.t
+++ b/t/project/meta.t
@@ -105,6 +105,7 @@ subtest 'resources' => sub {
             my $resources = $prepare_meta_json_resources->($git_conf_url);
             is $resources->{bugtracker}->{web}, 'https://github.com/tokuhirom/Minilla/issues';
             is $resources->{homepage}, 'https://github.com/tokuhirom/Minilla';
+            is $resources->{repository}->{type}, "git";
             is $resources->{repository}->{url}, 'https://github.com/tokuhirom/Minilla.git';
             is $resources->{repository}->{web}, 'https://github.com/tokuhirom/Minilla'
         };
@@ -145,6 +146,7 @@ subtest 'resources' => sub {
             my $resources = $prepare_meta_json_resources->($git_conf_url);
             is $resources->{bugtracker}->{web}, 'https://gitlab.com/tokuhirom/Minilla/issues';
             is $resources->{homepage}, 'https://gitlab.com/tokuhirom/Minilla';
+            is $resources->{repository}->{type}, "git";
             is $resources->{repository}->{url}, 'https://gitlab.com/tokuhirom/Minilla.git';
             is $resources->{repository}->{web}, 'https://gitlab.com/tokuhirom/Minilla'
         };
@@ -185,6 +187,7 @@ subtest 'resources' => sub {
             my $resources = $prepare_meta_json_resources->($git_conf_url);
             is $resources->{bugtracker}->{web}, 'https://gitlab.com/group/subgroup/Minilla/issues';
             is $resources->{homepage}, 'https://gitlab.com/group/subgroup/Minilla';
+            is $resources->{repository}->{type}, "git";
             is $resources->{repository}->{url}, 'https://gitlab.com/group/subgroup/Minilla.git';
             is $resources->{repository}->{web}, 'https://gitlab.com/group/subgroup/Minilla'
         };
@@ -223,6 +226,7 @@ subtest 'resources' => sub {
         my $resources_url_of_meta_json_ok = sub {
             my ($git_conf_url, $expected_url) = @_;
             my $resources = $prepare_meta_json_resources->($git_conf_url);
+            is $resources->{repository}->{type}, "git";
             is $resources->{repository}->{url}, $expected_url
                 or diag explain $resources;
         };


### PR DESCRIPTION
In #315, I changed the git url protocol from `git://` to `https://`.

OTOH, CPAN::Meta fills in the repository type `git` only if the url starts with `git://`.
https://github.com/Perl-Toolchain-Gang/CPAN-Meta/blob/67802250f9d6556b5b219684e9bc8f68588459ce/lib/CPAN/Meta/Converter.pm#L672

So I should have specify repository type `git`.