### PR TITLE
update github actions badge url

### DIFF
--- a/lib/Minilla.pm
+++ b/lib/Minilla.pm
@@ -260,7 +260,7 @@ See L<CPAN::Meta::Spec>.
 
 =item badges
 
-    badges = ['travis-ci.com', 'travis-ci.org', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter', 'metacpan', 'kritika', 'github-actions/$workflow_name', 'gitlab-pipeline', 'gitlab-coverage']
+    badges = ['travis-ci.com', 'travis-ci.org', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter', 'metacpan', 'kritika', 'github-actions/$workflow_file', 'gitlab-pipeline', 'gitlab-coverage']
 
 Embed badges image (e.g. Travis-CI) to README.md. It ought to be array and each elements must be service name. Now, supported services are 'travis-ci.com', 'travis-ci.org', 'circleci', 'appveyor', 'coveralls', 'codecov', 'gitter', 'metacpan', 'kritika' 'github-actions', 'gitlab-pipeline' and 'gitlab-coverage'.
 

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -717,8 +717,12 @@ sub regenerate_readme_md {
                     $image_uri->path("/users/$user_name/repos/$user_name+$repository_name/heads/$branch/status.svg");
                     push @badges, "[![Kritika Status]($image_uri)]($build_uri)";
                 } elsif ($service_name =~ m!^github-actions(?:/(.+))?$!) {
-                    my $workflow_name = $1 || 'test';
-                    push @badges, "[![Actions Status](https://github.com/$user_name/$repository_name/workflows/$workflow_name/badge.svg)](https://github.com/$user_name/$repository_name/actions)";
+                    my $workflow_file = $1 || 'test';
+                    if ($workflow_file =~ /\.(?:yml|yaml)$/) {
+                        push @badges, "[![Actions Status](https://github.com/$user_name/$repository_name/actions/workflows/$workflow_file/badge.svg)](https://github.com/$user_name/$repository_name/actions)";
+                    } else {
+                        push @badges, "[![Actions Status](https://github.com/$user_name/$repository_name/workflows/$workflow_file/badge.svg)](https://github.com/$user_name/$repository_name/actions)";
+                    }
                 } elsif ($service_name eq 'gitlab-pipeline') {
                     push @badges, "[![Gitlab pipeline](https://gitlab.com/$user_name/$repository_name/badges/$branch/pipeline.svg)](https://gitlab.com/$user_name/$repository_name/-/commits/$branch)";
                 } elsif ($service_name eq 'gitlab-coverage') {

--- a/minil.toml
+++ b/minil.toml
@@ -1,4 +1,4 @@
 name="Minilla"
 authority = "cpan:TOKUHIROM"
 module_maker = "ModuleBuildTiny"
-badges = ['github-actions/test', 'metacpan']
+badges = ['github-actions/test.yml', 'metacpan']

--- a/t/project/badge.t
+++ b/t/project/badge.t
@@ -127,10 +127,10 @@ subtest 'Badge' => sub {
         is $got, $expected;
     };
 
-    subtest 'GitHub Actions workflow name' => sub {
+    subtest 'GitHub Actions workflow file / name' => sub {
         write_minil_toml({
             name   => 'Acme-Foo',
-            badges => ['github-actions/foo'],
+            badges => ['github-actions/foo.yml', 'github-actions/foo'],
         });
         $project->regenerate_files;
 
@@ -138,6 +138,7 @@ subtest 'Badge' => sub {
         ok chomp (my $got = <$fh>);
 
         my $badge_markdowns = [
+            "[![Actions Status](https://github.com/tokuhirom/Minilla/actions/workflows/foo.yml/badge.svg)](https://github.com/tokuhirom/Minilla/actions)",
             "[![Actions Status](https://github.com/tokuhirom/Minilla/workflows/foo/badge.svg)](https://github.com/tokuhirom/Minilla/actions)",
         ];
         my $expected = join(' ', @$badge_markdowns);


### PR DESCRIPTION
At some point, it seems that github changes the badge url of github actions.
https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/adding-a-workflow-status-badge

before: https://github.com/tokuhirom/Minilla/workflows/test/badge.svg
after: https://github.com/tokuhirom/Minilla/actions/workflows/test.yml/badge.svg

This PR follows it.
