### PR TITLE
Change from Travis to GitHub Actions

### DIFF
--- a/lib/Minilla/Profile/Base.pm
+++ b/lib/Minilla/Profile/Base.pm
@@ -173,21 +173,46 @@ it under the same terms as Perl itself.
 
 =cut
 
-@@ .travis.yml
-language: perl
-matrix:
-  include:
-    - perl: "5.12"
-      dist: trusty
-    - perl: "5.14"
-    - perl: "5.16"
-    - perl: "5.18"
-    - perl: "5.20"
-    - perl: "5.22"
-    - perl: "5.24"
-    - perl: "5.26"
-    - perl: "5.28"
-    - perl: "5.30"
+@@ github_actions_test.yml
+name: test
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        perl:
+          [
+            "5.34",
+            "5.32",
+            "5.30",
+            "5.28",
+            "5.26",
+            "5.24",
+            "5.22",
+            "5.20",
+            "5.18",
+            "5.16",
+            "5.14",
+            "5.12",
+            "5.10"
+          ]
+    name: Perl ${{ matrix.perl }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup perl
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: ${{ matrix.perl }}
+      - name: Install dependencies
+        run: |
+          cpanm -nq --installdeps --with-develop --with-recommends .
+      - name: Build
+        run: |
+          perl Build.PL
+          ./Build
+      - name: Run test
+        run: ./Build test
 
 @@ Changes
 Revision history for Perl extension <% $dist %>

--- a/lib/Minilla/Profile/ExtUtilsMakeMaker.pm
+++ b/lib/Minilla/Profile/ExtUtilsMakeMaker.pm
@@ -21,7 +21,7 @@ sub generate {
 
     $self->render('Changes');
     $self->render('t/00_compile.t');
-    $self->render('.travis.yml');
+    $self->render('github_actions_test.yml', catfile('.github', 'workflows', 'test.yml'));
 
     $self->render('.gitignore');
     $self->write_file('LICENSE', Minilla::License::Perl_5->new(

--- a/lib/Minilla/Profile/ModuleBuild.pm
+++ b/lib/Minilla/Profile/ModuleBuild.pm
@@ -21,7 +21,7 @@ sub generate {
 
     $self->render('Changes');
     $self->render('t/00_compile.t');
-    $self->render('.travis.yml');
+    $self->render('github_actions_test.yml', catfile('.github', 'workflows', 'test.yml'));
 
     $self->render('.gitignore');
     $self->write_file('LICENSE', Minilla::License::Perl_5->new(

--- a/lib/Minilla/Profile/ModuleBuildTiny.pm
+++ b/lib/Minilla/Profile/ModuleBuildTiny.pm
@@ -21,7 +21,7 @@ sub generate {
 
     $self->render('Changes');
     $self->render('t/00_compile.t');
-    $self->render('.travis.yml');
+    $self->render('github_actions_test.yml', catfile('.github', 'workflows', 'test.yml'));
 
     $self->render('.gitignore');
     $self->write_file('LICENSE', Minilla::License::Perl_5->new(

--- a/lib/Minilla/Profile/XS.pm
+++ b/lib/Minilla/Profile/XS.pm
@@ -34,7 +34,7 @@ sub generate {
     $self->render('Changes');
     $self->render('t/00_compile.t');
     $self->render('t/01_simple.t');
-    $self->render('.travis.yml');
+    $self->render('github_actions_test.yml', catfile('.github', 'workflows', 'test.yml'));
 
     $self->render('.gitignore');
     my $gi = Minilla::Gitignore->load('.gitignore');

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -616,7 +616,7 @@ sub generate_minil_toml {
     my $project_name = $self->_detect_project_name_from_dir;
     my $content      = join("\n",
         qq{name = "$project_name"},
-        qq{badges = ["github-actions/test"]},
+        qq{badges = ["github-actions/test.yml"]},
     );
 
     my %pause;

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -616,7 +616,7 @@ sub generate_minil_toml {
     my $project_name = $self->_detect_project_name_from_dir;
     my $content      = join("\n",
         qq{name = "$project_name"},
-        qq{# badges = ["travis-ci.com"]},
+        qq{badges = ["github-actions/test"]},
     );
 
     my %pause;

--- a/t/03_step.t
+++ b/t/03_step.t
@@ -16,7 +16,7 @@ rmtree('Acme-Foo');
 
 is(minil('new', '--username=anonymous', '--email=foo@example.com','Acme::Foo'), 0);
 ok(-f 'Acme-Foo/Build.PL');
-ok(-f 'Acme-Foo/.travis.yml');
+ok(-f 'Acme-Foo/.github/workflows/test.yml');
 ok(-f 'Acme-Foo/t/00_compile.t');
 {
     local $ENV{PERL_MM_USE_DEFAULT} = 1;

--- a/t/profile-xs.t
+++ b/t/profile-xs.t
@@ -30,7 +30,7 @@ ok(-f 'Build.PL');
 cmp_ok((-s 'Build.PL'), '>', 0);
 ok(-f 'lib/Acme/Foo.pm');
 like(slurp('lib/Acme/Foo.pm'), qr{XSLoader});
-ok(-f '.travis.yml');
+ok(-f '.github/workflows/test.yml');
 ok(-f 't/00_compile.t');
 note(join(" ", git_ls_files()));
 note slurp('.gitignore');


### PR DESCRIPTION
This pull request changes CI from Travis to GitHub Actions.

Note:
I considered making both Travis and GitHub Actions available for compability. However, I thought it would be better to keep Minilla simple, so used only GitHub Actions.