### PR TITLE
use just "prove" in github actions template

### DIFF
--- a/lib/Minilla/Profile/Base.pm
+++ b/lib/Minilla/Profile/Base.pm
@@ -205,14 +205,9 @@ jobs:
         with:
           perl-version: ${{ matrix.perl }}
       - name: Install dependencies
-        run: |
-          cpanm -nq --installdeps --with-develop --with-recommends .
-      - name: Build
-        run: |
-          perl Build.PL
-          ./Build
+        run: cpanm -nq --installdeps --with-develop --with-recommends .
       - name: Run test
-        run: ./Build test
+        run: prove -lr t
 
 @@ Changes
 Revision history for Perl extension <% $dist %>


### PR DESCRIPTION
Minilla defaults to create distributions with Module::Build::Tiny's Build.PL.
While Minilla correctly adds Module::Build::Tiny as a configure dependency to META.json,
if we manually execute Build.PL, we need to install Module::Build::Tiny first.

Let's simply use `prove` in github actions template.