### PR TITLE
Fix for git 2.38.1 or higher versions

### DIFF
--- a/lib/Minilla/Git.pm
+++ b/lib/Minilla/Git.pm
@@ -5,7 +5,7 @@ use utf8;
 
 use parent qw(Exporter);
 
-our @EXPORT = qw(git_ls_files git_init git_add git_rm git_commit git_config git_remote git_submodule_add git_submodules git_submodule_files git_show_toplevel);
+our @EXPORT = qw(git_ls_files git_init git_add git_rm git_commit git_config git_remote git_submodules git_submodule_files git_show_toplevel);
 
 use Minilla::Logger qw(errorf);
 use Minilla::Util qw(cmd);
@@ -37,10 +37,6 @@ sub git_remote {
 sub git_ls_files {
     my @files = split /\0/, `git ls-files -z`;
     return @files;
-}
-
-sub git_submodule_add {
-    cmd('git', 'submodule', 'add', @_);
 }
 
 sub git_submodules {
@@ -83,4 +79,3 @@ sub git_show_toplevel {
 }
 
 1;
-

--- a/t/filegatherer/submodules-recursive.t
+++ b/t/filegatherer/submodules-recursive.t
@@ -68,7 +68,7 @@ sub init {
     git_init();
     git_add('.');
     git_submodule_add("file://$submodule_repos{$_}", "lib$_") for keys %submodule_repos;
-    system 'git submodule update --init --recursive';
+    git_submodule_update_init_recursive();
     git_commit('-m', 'foo');
 
     $guard;

--- a/t/lib/Util.pm
+++ b/t/lib/Util.pm
@@ -26,7 +26,7 @@ $ENV{PERL_CPANM_HOME} = tempdir(CLEANUP => 1);
 delete $ENV{GIT_CONFIG};
 
 our @EXPORT = (
-    qw(git_init_add_commit write_minil_toml),
+    qw(git_init_add_commit git_submodule_add git_submodule_update_init_recursive write_minil_toml),
     qw(tempdir pushd),
     @Minilla::Git::EXPORT, @Minilla::Util::EXPORT_OK, qw(spew),
     qw(catfile),
@@ -37,6 +37,17 @@ sub git_init_add_commit() {
     git_init();
     git_add('.');
     git_commit('-m', 'initial import');
+}
+
+# Cloning from local file system is disabled by default since git 2.38.1
+# So set 'protocol.file.allow=always'
+# - https://github.blog/2022-10-18-git-security-vulnerabilities-announced/#cve-2022-39253
+sub git_submodule_add {
+    cmd('git', '-c', 'protocol.file.allow=always', 'submodule', 'add', @_);
+}
+
+sub git_submodule_update_init_recursive {
+    cmd('git', '-c', 'protocol.file.allow=always', 'submodule', 'update', '--init', '--recursive');
 }
 
 sub write_minil_toml {
@@ -51,4 +62,3 @@ sub write_minil_toml {
 }
 
 1;
-


### PR DESCRIPTION
Since git 2.38.1, cloning from local file is disabled by default for security issue. This makes tests fail. So set 'protocol.file.allow=always' for avoiding this issue.

And move 'git_submodule_add' utility function to 't/Util.t' because it is used only from test code.

Reference
- https://github.com/tokuhirom/Minilla/issues/322#issuecomment-1311702767
- https://github.com/tokuhirom/Minilla/issues/322#issuecomment-1311772119