### PR TITLE
Use git command to get branch name instead of parsing HEAD file

### DIFF
--- a/lib/Minilla/Release/Commit.pm
+++ b/lib/Minilla/Release/Commit.pm
@@ -32,20 +32,11 @@ sub _push_to_origin {
     my ($self) = @_;
 
     # git v1.7.10 is required?
-    my $branch = _get_branch()
+    my $branch = `git symbolic-ref --short HEAD`
         or return;
     $branch =~ s/\n//g;
     infof("Pushing to origin\n");
     cmd('git', 'push', 'origin', $branch);
-}
-
-sub _get_branch {
-    open my $fh, '<', '.git/HEAD';
-    chomp( my $head = do { local $/; <$fh> });
-    close $fh;
-
-    my ($branch) = $head =~ m!ref: refs/heads/(\S+)!;
-    return $branch;
 }
 
 1;


### PR DESCRIPTION
Current code gets branch name by parsing HEAD file for older git. However developers no longer use such old git. 1.17.0 was released 10 years ago(2012/APR/7).

Close #322 

Reference
- https://github.com/tokuhirom/Minilla/issues/322#issue-1390173116