### PR TITLE
do not set x_authority by default

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -21,7 +21,6 @@ requires 'App::cpanminus', '1.6902';
 requires 'Module::CPANfile', '0.9025';
 requires 'Module::Metadata' => '1.000027';
 requires 'Pod::Markdown', '1.322';
-requires 'Config::Identity';
 
 # File operation
 requires 'File::pushd';

--- a/lib/Minilla.pm
+++ b/lib/Minilla.pm
@@ -201,6 +201,9 @@ Grab authors information from the file contains pod.
 
 Set x_authority attribute to META.
 See L<https://jawnsy.wordpress.com/2011/02/20/what-is-x_authority/> for more details.
+Note that now PAUSE itself copies the permissions from the "main module"
+to any new modules entering the index for the first time,
+so you don't need to set this attribute anymore.
 
 =item allow_pureperl
 

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -10,7 +10,6 @@ use DirHandle;
 use File::pushd;
 use CPAN::Meta;
 use Module::CPANfile;
-use Config::Identity::PAUSE;
 use Module::Runtime qw(require_module);
 
 use Minilla;
@@ -618,13 +617,6 @@ sub generate_minil_toml {
         qq{name = "$project_name"},
         qq{badges = ["github-actions/test.yml"]},
     );
-
-    my %pause;
-    if (eval { %pause = Config::Identity::PAUSE->load; 1; } && exists $pause{user}) {
-        my $user = uc($pause{user});
-        $content .= qq(\nauthority="cpan:${user}"\n);
-    }
-    warn $@ if $@;
 
     if ($profile eq 'ModuleBuild') {
         $content .= qq{\nmodule_maker="ModuleBuild"\n};

--- a/minil.toml
+++ b/minil.toml
@@ -1,4 +1,3 @@
 name="Minilla"
-authority = "cpan:TOKUHIROM"
 module_maker = "ModuleBuildTiny"
 badges = ['github-actions/test.yml', 'metacpan']


### PR DESCRIPTION
Now PAUSE itself copies the permissions from the "main module"
to any new modules entering the index for the first time,
so we don't need to set x_authority anymore.

See
https://github.com/andk/pause/pull/222
https://github.com/karenetheridge/Dist-Zilla-Plugin-AuthorityFromModule/commit/dad604f7cf0fa502a4553bcdcada01193c4f626f