### PR TITLE
Update GitHub Actions status badge URLs to match the latest documentation

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl extension Minilla
 
 {{$NEXT}}
+    - Update GitHub Actions status badge URLs to match the latest documentation (Songmu #338)
 
 v3.1.26 2025-05-05T03:05:23Z
     - Update Perl_5 license text (#336)

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -709,12 +709,14 @@ sub regenerate_readme_md {
                     $image_uri->path("/users/$user_name/repos/$user_name+$repository_name/heads/$branch/status.svg");
                     push @badges, "[![Kritika Status]($image_uri)]($build_uri)";
                 } elsif ($service_name =~ m!^github-actions(?:/(.+))?$!) {
-                    my $workflow_file = $1 || 'test';
-                    if ($workflow_file =~ /\.(?:yml|yaml)$/) {
-                        push @badges, "[![Actions Status](https://github.com/$user_name/$repository_name/actions/workflows/$workflow_file/badge.svg)](https://github.com/$user_name/$repository_name/actions)";
-                    } else {
-                        push @badges, "[![Actions Status](https://github.com/$user_name/$repository_name/workflows/$workflow_file/badge.svg)](https://github.com/$user_name/$repository_name/actions)";
+                    # ref. https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge
+                    my $workflow_file = $1 || 'test.yml';
+                    if ($workflow_file !~ /\.(?:yml|yaml)$/) {
+                        $workflow_file .= '.yml';
                     }
+                    my $workflow_name = $workflow_file;
+                    $workflow_name =~ s/\.ya?ml$//;
+                    push @badges, "[![Actions Status](https://github.com/$user_name/$repository_name/actions/workflows/$workflow_file/badge.svg?branch=$branch)](https://github.com/$user_name/$repository_name/actions?workflow=$workflow_name)";
                 } elsif ($service_name eq 'gitlab-pipeline') {
                     push @badges, "[![Gitlab pipeline](https://gitlab.com/$user_name/$repository_name/badges/$branch/pipeline.svg)](https://gitlab.com/$user_name/$repository_name/-/commits/$branch)";
                 } elsif ($service_name eq 'gitlab-coverage') {

--- a/t/project/badge.t
+++ b/t/project/badge.t
@@ -55,7 +55,7 @@ subtest 'Badge' => sub {
             "[![Gitter chat](https://badges.gitter.im/tokuhirom/Minilla.png)](https://gitter.im/tokuhirom/Minilla)",
             "[![Coverage Status](http://codecov.io/github/tokuhirom/Minilla/coverage.svg?branch=master)](https://codecov.io/github/tokuhirom/Minilla?branch=master)",
             "[![MetaCPAN Release](https://badge.fury.io/pl/Acme-Foo.svg)](https://metacpan.org/release/Acme-Foo)",
-            "[![Actions Status](https://github.com/tokuhirom/Minilla/workflows/test/badge.svg)](https://github.com/tokuhirom/Minilla/actions)",
+            "[![Actions Status](https://github.com/tokuhirom/Minilla/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/tokuhirom/Minilla/actions?workflow=test)",
         ];
         my $expected = join(' ', @$badge_markdowns);
         is $got, $expected;
@@ -138,8 +138,8 @@ subtest 'Badge' => sub {
         ok chomp (my $got = <$fh>);
 
         my $badge_markdowns = [
-            "[![Actions Status](https://github.com/tokuhirom/Minilla/actions/workflows/foo.yml/badge.svg)](https://github.com/tokuhirom/Minilla/actions)",
-            "[![Actions Status](https://github.com/tokuhirom/Minilla/workflows/foo/badge.svg)](https://github.com/tokuhirom/Minilla/actions)",
+            "[![Actions Status](https://github.com/tokuhirom/Minilla/actions/workflows/foo.yml/badge.svg?branch=master)](https://github.com/tokuhirom/Minilla/actions?workflow=foo)",
+            "[![Actions Status](https://github.com/tokuhirom/Minilla/actions/workflows/foo.yml/badge.svg?branch=master)](https://github.com/tokuhirom/Minilla/actions?workflow=foo)",
         ];
         my $expected = join(' ', @$badge_markdowns);
         is $got, $expected;


### PR DESCRIPTION
The URLs associated with workflow names have been deprecated and now return a 404 error. So, I have changed the URLs to be derived from the workflow file names. This URL format is documented and stable.

Ref. https://docs.github.com/en/actions/how-tos/monitor-workflows/add-a-status-badge