### PR TITLE
Fix issue 340

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -19,7 +19,7 @@ requires 'Text::MicroTemplate', '0.20';
 # CPAN related
 requires 'App::cpanminus', '1.6902';
 requires 'Module::CPANfile', '0.9025';
-requires 'Module::Metadata' => '1.000027';
+requires 'Module::Metadata' => '1.000037';
 requires 'Pod::Markdown', '1.322';
 
 # File operation

--- a/cpanfile
+++ b/cpanfile
@@ -32,6 +32,7 @@ requires 'Moo' => 1.001000;
 # Utilities
 requires 'Data::Section::Simple' => 0.04;
 requires 'Term::ANSIColor';
+requires 'Term::Encoding';
 requires 'Module::Runtime';
 requires 'URI';
 

--- a/lib/Minilla/Metadata.pm
+++ b/lib/Minilla/Metadata.pm
@@ -36,7 +36,7 @@ no Moo;
 
 sub _build_metadata {
     my $self = shift;
-    Module::Metadata->new_from_file($self->source, collect_pod => 1);
+    Module::Metadata->new_from_file($self->source, collect_pod => 1, decode_pod => 1);
 }
 
 # Taken from Module::Install::Metadata

--- a/lib/Minilla/Project.pm
+++ b/lib/Minilla/Project.pm
@@ -25,6 +25,7 @@ use Minilla::ModuleMaker::ExtUtilsMakeMaker;
 use Minilla::Util qw(slurp_utf8 find_dir cmd spew_raw slurp_raw spew_utf8);
 use Encode qw(decode_utf8);
 use URI;
+use Term::Encoding qw(term_encoding);
 
 use Moo;
 
@@ -351,7 +352,7 @@ sub _build_metadata {
         %$config,
     );
     infof("Name: %s\n", $metadata->name);
-    infof("Abstract: %s\n", $metadata->abstract);
+    infof("Abstract: %s\n", Encode::encode(term_encoding(), $metadata->abstract));
     infof("Version: %s\n", $metadata->version);
 
     return $metadata;


### PR DESCRIPTION
- pass `decode_pod` flag to `Module::Metadata::new_from_file`
- print the abstract that contains multi-byte characters correctly

See #340